### PR TITLE
Add cronjob for publishing meldingFraBehandler to kafka-topic

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -75,3 +75,5 @@ spec:
       value: "https://syfo-tilgangskontroll.dev-fss-pub.nais.io"
     - name: TOGGLE_PRODUCE_BEHANDLER_DIALOGMELDING_BESTILLING
       value: "true"
+    - name: TOGGLE_PRODUCE_MELDING_FRA_BEHANDLER
+      value: "false"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -75,3 +75,5 @@ spec:
       value: "https://syfo-tilgangskontroll.prod-fss-pub.nais.io"
     - name: TOGGLE_PRODUCE_BEHANDLER_DIALOGMELDING_BESTILLING
       value: "false"
+    - name: TOGGLE_PRODUCE_MELDING_FRA_BEHANDLER
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -43,6 +43,7 @@ data class Environment(
         ),
     ),
     val produceBehandlerDialogmeldingBestilling: Boolean = getEnvVar("TOGGLE_PRODUCE_BEHANDLER_DIALOGMELDING_BESTILLING").toBoolean(),
+    val produceMeldingFraBehandler: Boolean = getEnvVar("TOGGLE_PRODUCE_MELDING_FRA_BEHANDLER").toBoolean(),
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =

--- a/src/main/kotlin/no/nav/syfo/melding/cronjob/MeldingFraBehandlerCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/cronjob/MeldingFraBehandlerCronjob.kt
@@ -1,0 +1,44 @@
+package no.nav.syfo.melding.cronjob
+
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.application.cronjob.Cronjob
+import no.nav.syfo.application.cronjob.CronjobResult
+import no.nav.syfo.melding.kafka.PublishMeldingFraBehandlerService
+import org.slf4j.LoggerFactory
+
+class MeldingFraBehandlerCronjob(
+    val publishMeldingFraBehandlerService: PublishMeldingFraBehandlerService,
+) : Cronjob {
+    override val initialDelayMinutes: Long = 2
+    override val intervalDelayMinutes: Long = 10
+
+    override suspend fun run() {
+        val result = runJob()
+        log.info(
+            "Completed publishing meldingFraBehandler processing job with result: {}, {}",
+            StructuredArguments.keyValue("failed", result.failed),
+            StructuredArguments.keyValue("updated", result.updated),
+        )
+    }
+
+    fun runJob(): CronjobResult {
+        val result = CronjobResult()
+        val unpublishedMeldingerFraBehandler = publishMeldingFraBehandlerService.getUnpublishedMeldingerFraBehandler()
+
+        unpublishedMeldingerFraBehandler.forEach { pMelding ->
+            try {
+                publishMeldingFraBehandlerService.publishMeldingFraBehandler(pMelding)
+                result.updated++
+            } catch (e: Exception) {
+                log.error("Caught exception in published meldingFraBehandler")
+                result.failed++
+            }
+        }
+
+        return result
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(MeldingFraBehandlerCronjob::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/melding/database/domain/PMelding.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/database/domain/PMelding.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.melding.database.domain
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.melding.domain.*
+import no.nav.syfo.melding.kafka.domain.KafkaMeldingFraBehandlerDTO
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -51,4 +52,15 @@ fun PMelding.toMeldingFraBehandler() = MeldingFraBehandler(
     behandlerNavn = behandlerNavn,
     tekst = tekst ?: "",
     antallVedlegg = antallVedlegg,
+)
+
+fun PMelding.toKafkaMeldingFraBehandlerDTO() = KafkaMeldingFraBehandlerDTO(
+    uuid = uuid.toString(),
+    personIdent = arbeidstakerPersonIdent,
+    type = type,
+    conversationRef = conversationRef.toString(),
+    parentRef = parentRef?.toString(),
+    msgId = msgId,
+    tidspunkt = tidspunkt,
+    behandlerPersonIdent = behandlerPersonIdent,
 )

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/KafkaMeldingFraBehandlerProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/KafkaMeldingFraBehandlerProducer.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.melding.kafka
+
+import no.nav.syfo.melding.kafka.domain.KafkaMeldingFraBehandlerDTO
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+import java.util.*
+
+class KafkaMeldingFraBehandlerProducer(
+    private val kafkaMeldingFraBehandlerProducer: KafkaProducer<String, KafkaMeldingFraBehandlerDTO>,
+) {
+    fun sendMeldingFraBehandler(
+        kafkaMeldingFraBehandlerDTO: KafkaMeldingFraBehandlerDTO,
+        key: UUID,
+    ) {
+        try {
+            kafkaMeldingFraBehandlerProducer.send(
+                ProducerRecord(
+                    MELDING_FRA_BEHANDLER_TOPIC,
+                    key.toString(),
+                    kafkaMeldingFraBehandlerDTO,
+                )
+            ).get()
+        } catch (e: Exception) {
+            log.error("Exception was thrown when attempting to send kafkaMeldingFraBehandlerDTO with id $key: ${e.message}")
+            throw e
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(KafkaMeldingFraBehandlerProducer::class.java)
+        const val MELDING_FRA_BEHANDLER_TOPIC = "teamsykefravr.melding-fra-behandler"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/PublishMeldingFraBehandlerService.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/PublishMeldingFraBehandlerService.kt
@@ -1,0 +1,30 @@
+package no.nav.syfo.melding.kafka
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.melding.database.domain.PMelding
+import no.nav.syfo.melding.database.domain.toKafkaMeldingFraBehandlerDTO
+import no.nav.syfo.melding.database.getUnpublishedMeldingerFraBehandler
+import no.nav.syfo.melding.database.updateInnkommendePublishedAt
+import java.util.*
+
+class PublishMeldingFraBehandlerService(
+    private val database: DatabaseInterface,
+    private val kafkaMeldingFraBehandlerProducer: KafkaMeldingFraBehandlerProducer,
+) {
+    fun getUnpublishedMeldingerFraBehandler(): List<PMelding> {
+        return database.getUnpublishedMeldingerFraBehandler()
+    }
+
+    fun publishMeldingFraBehandler(
+        pMelding: PMelding,
+    ) {
+        kafkaMeldingFraBehandlerProducer.sendMeldingFraBehandler(
+            kafkaMeldingFraBehandlerDTO = pMelding.toKafkaMeldingFraBehandlerDTO(),
+            key = UUID.nameUUIDFromBytes(pMelding.arbeidstakerPersonIdent.toByteArray()),
+        )
+
+        database.updateInnkommendePublishedAt(
+            uuid = pMelding.uuid,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/config/KafkaMeldingFraBehandlerProducerConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/config/KafkaMeldingFraBehandlerProducerConfig.kt
@@ -1,0 +1,16 @@
+package no.nav.syfo.melding.kafka.config
+
+import no.nav.syfo.application.kafka.KafkaEnvironment
+import no.nav.syfo.application.kafka.kafkaAivenProducerConfig
+import no.nav.syfo.melding.kafka.domain.KafkaMeldingFraBehandlerDTO
+import org.apache.kafka.clients.producer.KafkaProducer
+
+fun kafkaMeldingFraBehandlerProducerConfig(
+    applicationEnvironmentKafka: KafkaEnvironment,
+): KafkaProducer<String, KafkaMeldingFraBehandlerDTO> {
+    return KafkaProducer(
+        kafkaAivenProducerConfig<KafkaMeldingFraBehandlerSerializer>(
+            kafkaEnvironment = applicationEnvironmentKafka,
+        )
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/config/KafkaMeldingFraBehandlerSerializer.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/config/KafkaMeldingFraBehandlerSerializer.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.melding.kafka.config
+
+import no.nav.syfo.melding.kafka.domain.KafkaMeldingFraBehandlerDTO
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.common.serialization.Serializer
+
+class KafkaMeldingFraBehandlerSerializer : Serializer<KafkaMeldingFraBehandlerDTO> {
+    private val mapper = configuredJacksonMapper()
+    override fun serialize(topic: String?, data: KafkaMeldingFraBehandlerDTO?): ByteArray =
+        mapper.writeValueAsBytes(data)
+}

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/domain/KafkaMeldingFraBehandlerDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/domain/KafkaMeldingFraBehandlerDTO.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.melding.kafka.domain
+
+import java.time.OffsetDateTime
+
+data class KafkaMeldingFraBehandlerDTO(
+    val uuid: String,
+    val personIdent: String,
+    val type: String,
+    val conversationRef: String,
+    val parentRef: String?,
+    val msgId: String?,
+    val tidspunkt: OffsetDateTime,
+    val behandlerPersonIdent: String?,
+)

--- a/src/test/kotlin/no/nav/syfo/melding/cronjob/MeldingFraBehandlerCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/cronjob/MeldingFraBehandlerCronjobSpek.kt
@@ -1,0 +1,101 @@
+package no.nav.syfo.melding.cronjob
+
+import io.ktor.server.testing.*
+import io.mockk.clearMocks
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.melding.database.getMeldingerForArbeidstaker
+import no.nav.syfo.melding.database.updateInnkommendePublishedAt
+import no.nav.syfo.melding.kafka.KafkaMeldingFraBehandlerProducer
+import no.nav.syfo.melding.kafka.PublishMeldingFraBehandlerService
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.createMeldingerFraBehandler
+import no.nav.syfo.testhelper.dropData
+import no.nav.syfo.testhelper.generator.generateMeldingFraBehandler
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.*
+
+class MeldingFraBehandlerCronjobSpek : Spek({
+
+    with(TestApplicationEngine()) {
+        start()
+        val database = ExternalMockEnvironment.instance.database
+
+        val kafkaMeldingFraBehandlerProducer = mockk<KafkaMeldingFraBehandlerProducer>()
+        justRun {
+            kafkaMeldingFraBehandlerProducer.sendMeldingFraBehandler(
+                kafkaMeldingFraBehandlerDTO = any(),
+                key = any(),
+            )
+        }
+
+        val publishMeldingFraBehandlerService = PublishMeldingFraBehandlerService(
+            database = database,
+            kafkaMeldingFraBehandlerProducer = kafkaMeldingFraBehandlerProducer,
+        )
+
+        val meldingFraBehandlerCronjob = MeldingFraBehandlerCronjob(
+            publishMeldingFraBehandlerService = publishMeldingFraBehandlerService,
+        )
+
+        describe(MeldingFraBehandlerCronjob::class.java.simpleName) {
+            describe("Test cronjob") {
+                afterEachTest {
+                    database.dropData()
+                    clearMocks(kafkaMeldingFraBehandlerProducer)
+                }
+
+                it("Will update innkommende_published_at when cronjob publish on kafka") {
+                    val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
+                    val meldingFraBehandler = generateMeldingFraBehandler(
+                        conversationRef = UUID.randomUUID(),
+                        personIdent = personIdent,
+                    )
+                    database.createMeldingerFraBehandler(
+                        meldingFraBehandler = meldingFraBehandler,
+                    )
+
+                    runBlocking {
+                        val result = meldingFraBehandlerCronjob.runJob()
+
+                        result.failed shouldBeEqualTo 0
+                        result.updated shouldBeEqualTo 1
+                    }
+
+                    verify(exactly = 1) { kafkaMeldingFraBehandlerProducer.sendMeldingFraBehandler(any(), any()) }
+
+                    val meldinger = database.getMeldingerForArbeidstaker(personIdent)
+                    meldinger.first().innkommendePublishedAt shouldNotBeEqualTo null
+                }
+
+                it("Will not send to kafka if no unpublished meldingFraBehandler") {
+                    val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
+                    val meldingFraBehandler = generateMeldingFraBehandler(
+                        conversationRef = UUID.randomUUID(),
+                        personIdent = personIdent,
+                    )
+                    database.createMeldingerFraBehandler(
+                        meldingFraBehandler = meldingFraBehandler,
+                    )
+                    val meldinger = database.getMeldingerForArbeidstaker(personIdent)
+                    database.updateInnkommendePublishedAt(uuid = meldinger.first().uuid)
+
+                    runBlocking {
+                        val result = meldingFraBehandlerCronjob.runJob()
+
+                        result.failed shouldBeEqualTo 0
+                        result.updated shouldBeEqualTo 0
+                    }
+
+                    verify(exactly = 0) { kafkaMeldingFraBehandlerProducer.sendMeldingFraBehandler(any(), any()) }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -46,6 +46,7 @@ fun testEnvironment(
     ),
     electorPath = "electorPath",
     produceBehandlerDialogmeldingBestilling = true,
+    produceMeldingFraBehandler = true,
 )
 
 fun testAppState() = ApplicationState(


### PR DESCRIPTION
Oppsett for å sende på kafka, og for cronjob.
Tanken nå er å sende litt metadata om meldingen på kafka, men her kan vi diskutere hva som trenger å være med i en generell publisering av `meldingFraBehandler` på topic.

Neste PR blir å faktisk opprette topicen, ta den i bruk i dev, og kalle `cronjobModule` fra `App.kt` (evt gjøres nok også dette i journalføringsPR).

Co-authored-by: John Martin Lindseth <john.martin.lindseth@nav.no>