### PR TITLE
Store incoming legeerklaring

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -112,7 +112,6 @@ fun main() {
                 applicationState = applicationState,
                 kafkaEnvironment = environment.kafka,
                 database = applicationDatabase,
-                meldingService = meldingService,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
@@ -33,17 +33,20 @@ class KafkaLegeerklaringConsumer(
                 if (kafkaLegeerklaring != null) {
                     val conversationRef = kafkaLegeerklaring.conversationRef?.refToConversation
                     if (conversationRef != null) {
-                        val sendtMelding = connection.getUtgaendeMeldingerInConversation(
-                            conversationRef = UUID.fromString(conversationRef),
-                            arbeidstakerPersonIdent = PersonIdent(kafkaLegeerklaring.personNrPasient),
-                        )
-                        if (sendtMelding.isNotEmpty()) {
+                        if (
+                            connection.hasSendtMeldingForConversationRefAndArbeidstakerIdent(
+                                conversationRef = UUID.fromString(conversationRef),
+                                arbeidstakerPersonIdent = PersonIdent(kafkaLegeerklaring.personNrPasient),
+                            )
+                        ) {
                             connection.createMeldingFraBehandler(
                                 meldingFraBehandler = kafkaLegeerklaring.toMeldingFraBehandler(),
                                 fellesformat = null,
                                 commit = false,
                             )
                         }
+                    } else {
+                        // TODO: Handle missing conversationRef
                     }
                 } else {
                     COUNT_KAFKA_CONSUMER_LEGEERKLARING_TOMBSTONE.increment()

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringTask.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringTask.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.melding.kafka.legeerklaring
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.kafka.*
-import no.nav.syfo.melding.MeldingService
 import no.nav.syfo.util.configuredJacksonMapper
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.Deserializer
@@ -14,11 +13,9 @@ fun launchKafkaTaskLegeerklaring(
     applicationState: ApplicationState,
     kafkaEnvironment: KafkaEnvironment,
     database: DatabaseInterface,
-    meldingService: MeldingService,
 ) {
     val kafkaLegeerklaringConsumer = KafkaLegeerklaringConsumer(
         database = database,
-        meldingService = meldingService,
     )
     val consumerProperties =
         kafkaConsumerConfig<KafkaLegeerklaringDeserializer>(kafkaEnvironment = kafkaEnvironment).apply {

--- a/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaLegeerklaringFraBehandlerConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaLegeerklaringFraBehandlerConsumerSpek.kt
@@ -1,0 +1,102 @@
+package no.nav.syfo.melding.kafka
+
+import io.ktor.server.testing.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.melding.database.*
+import no.nav.syfo.melding.domain.MeldingType
+import no.nav.syfo.melding.kafka.legeerklaring.KafkaLegeerklaringConsumer
+import no.nav.syfo.melding.kafka.legeerklaring.LEGEERKLARING_TOPIC
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.generator.*
+import no.nav.syfo.testhelper.mock.mockKafkaConsumer
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.*
+
+class KafkaLegeerklaringFraBehandlerConsumerSpek : Spek({
+
+    with(TestApplicationEngine()) {
+        start()
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+
+        val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
+        val behandlerPersonIdent = UserConstants.BEHANDLER_PERSONIDENT
+        val behandlerNavn = UserConstants.BEHANDLER_NAVN
+
+        afterEachTest {
+            database.dropData()
+        }
+
+        val kafkaLegeerklaringConsumer = KafkaLegeerklaringConsumer(
+            database = database,
+        )
+
+        describe("Read legeerklaring sent from behandler to NAV from Kafka Topic") {
+            describe("Happy path") {
+                it("Receive legerklaring") {
+                    val legeerklaring = generateKafkaLegeerklaringFraBehandlerDTO(
+                        behandlerPersonIdent = behandlerPersonIdent,
+                        behandlerNavn = behandlerNavn,
+                        personIdent = personIdent,
+                    )
+                    val mockConsumer = mockKafkaConsumer(legeerklaring, LEGEERKLARING_TOPIC)
+
+                    runBlocking {
+                        kafkaLegeerklaringConsumer.pollAndProcessRecords(
+                            kafkaConsumer = mockConsumer,
+                        )
+                    }
+
+                    verify(exactly = 1) { mockConsumer.commitSync() }
+
+                    database.getMeldingerForArbeidstaker(personIdent).size shouldBeEqualTo 0
+                }
+                it("Receive legeerklaring and known conversationRef") {
+                    val msgId = UUID.randomUUID().toString()
+                    val (conversationRef, _) = database.createMeldingerTilBehandler(
+                        defaultMeldingTilBehandler.copy(
+                            arbeidstakerPersonIdent = personIdent,
+                            behandlerPersonIdent = behandlerPersonIdent,
+                            behandlerNavn = behandlerNavn,
+                            type = MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING,
+                        )
+                    )
+                    val legeerklaring = generateKafkaLegeerklaringFraBehandlerDTO(
+                        behandlerPersonIdent = behandlerPersonIdent,
+                        behandlerNavn = behandlerNavn,
+                        personIdent = personIdent,
+                        msgId = msgId,
+                        conversationRef = conversationRef.toString(),
+                    )
+                    val mockConsumer = mockKafkaConsumer(legeerklaring, LEGEERKLARING_TOPIC)
+
+                    runBlocking {
+                        kafkaLegeerklaringConsumer.pollAndProcessRecords(
+                            kafkaConsumer = mockConsumer,
+                        )
+                    }
+
+                    verify(exactly = 1) { mockConsumer.commitSync() }
+
+                    val pMeldingListAfter = database.getMeldingerForArbeidstaker(personIdent)
+                    pMeldingListAfter.size shouldBeEqualTo 2
+                    val pSvar = pMeldingListAfter.last()
+                    pSvar.arbeidstakerPersonIdent shouldBeEqualTo personIdent.value
+                    pSvar.innkommende shouldBe true
+                    pSvar.msgId shouldBeEqualTo msgId.toString()
+                    pSvar.behandlerPersonIdent shouldBeEqualTo behandlerPersonIdent.value
+                    pSvar.behandlerNavn shouldBeEqualTo UserConstants.BEHANDLER_NAVN
+                    pSvar.antallVedlegg shouldBeEqualTo 0
+                    pSvar.veilederIdent shouldBeEqualTo null
+                    pSvar.type shouldBeEqualTo MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING.name
+                    val vedlegg = database.getVedlegg(pSvar.uuid, 0)
+                    vedlegg shouldBe null
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/LegeerklaringGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/LegeerklaringGenerator.kt
@@ -11,7 +11,7 @@ fun generateKafkaLegeerklaringFraBehandlerDTO(
     behandlerNavn: String,
     personIdent: PersonIdent,
     msgId: String = UUID.randomUUID().toString(),
-    conversationRef: String = UUID.randomUUID().toString(),
+    conversationRef: String? = UUID.randomUUID().toString(),
 ) = KafkaLegeerklaringDTO(
     legeerklaering = generateLegeerklaring(
         personIdent = personIdent.value,
@@ -25,10 +25,12 @@ fun generateKafkaLegeerklaringFraBehandlerDTO(
     legekontorHerId = "${UserConstants.HERID}",
     legekontorOrgName = "Legekontoret",
     mottattDato = LocalDateTime.now(),
-    conversationRef = ConversationRef(
-        refToParent = UUID.randomUUID().toString(),
-        refToConversation = conversationRef,
-    ),
+    conversationRef = conversationRef?.let {
+        ConversationRef(
+            refToParent = UUID.randomUUID().toString(),
+            refToConversation = conversationRef,
+        )
+    },
 )
 
 fun generateLegeerklaring(

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/LegeerklaringGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/LegeerklaringGenerator.kt
@@ -1,0 +1,125 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.melding.kafka.legeerklaring.*
+import no.nav.syfo.testhelper.UserConstants
+import java.time.LocalDateTime
+import java.util.UUID
+
+fun generateKafkaLegeerklaringFraBehandlerDTO(
+    behandlerPersonIdent: PersonIdent,
+    behandlerNavn: String,
+    personIdent: PersonIdent,
+    msgId: String = UUID.randomUUID().toString(),
+    conversationRef: String = UUID.randomUUID().toString(),
+) = KafkaLegeerklaringDTO(
+    legeerklaering = generateLegeerklaring(
+        personIdent = personIdent.value,
+        behandlerNavn = behandlerNavn,
+    ),
+    personNrPasient = personIdent.value,
+    personNrLege = behandlerPersonIdent.value,
+    navLogId = UUID.randomUUID().toString(),
+    msgId = msgId,
+    legekontorOrgNr = "999999999",
+    legekontorHerId = "${UserConstants.HERID}",
+    legekontorOrgName = "Legekontoret",
+    mottattDato = LocalDateTime.now(),
+    conversationRef = ConversationRef(
+        refToParent = UUID.randomUUID().toString(),
+        refToConversation = conversationRef,
+    ),
+)
+
+fun generateLegeerklaring(
+    personIdent: String,
+    behandlerNavn: String,
+) = Legeerklaering(
+    id = UUID.randomUUID().toString(),
+    arbeidsvurderingVedSykefravaer = false,
+    arbeidsavklaringspenger = false,
+    yrkesrettetAttforing = false,
+    uforepensjon = false,
+    pasient = Pasient(
+        fornavn = "Fornavn",
+        mellomnavn = null,
+        etternavn = "Etternavn",
+        fnr = personIdent,
+        adresse = null,
+        navKontor = null,
+        postnummer = null,
+        poststed = null,
+        yrke = null,
+        arbeidsgiver = Arbeidsgiver(
+            navn = null,
+            adresse = null,
+            poststed = null,
+            postnummer = null,
+        ),
+    ),
+    sykdomsopplysninger = Sykdomsopplysninger(
+        hoveddiagnose = null,
+        bidiagnose = emptyList(),
+        arbeidsuforFra = null,
+        sykdomshistorie = "",
+        statusPresens = "",
+        borNavKontoretVurdereOmDetErEnYrkesskade = false,
+        yrkesSkadeDato = null,
+    ),
+    plan = null,
+    forslagTilTiltak = ForslagTilTiltak(
+        behov = false,
+        kjopAvHelsetjenester = false,
+        reisetilskudd = false,
+        aktivSykmelding = false,
+        hjelpemidlerArbeidsplassen = false,
+        arbeidsavklaringspenger = false,
+        friskmeldingTilArbeidsformidling = false,
+        andreTiltak = null,
+        naermereOpplysninger = "",
+        tekst = "",
+    ),
+    funksjonsOgArbeidsevne = FunksjonsOgArbeidsevne(
+        vurderingFunksjonsevne = null,
+        inntektsgivendeArbeid = false,
+        hjemmearbeidende = false,
+        student = false,
+        annetArbeid = "",
+        kravTilArbeid = null,
+        kanGjenopptaTidligereArbeid = false,
+        kanGjenopptaTidligereArbeidNa = false,
+        kanGjenopptaTidligereArbeidEtterBehandling = false,
+        kanIkkeGjenopptaNaverendeArbeid = null,
+        kanTaAnnetArbeid = false,
+        kanTaAnnetArbeidNa = false,
+        kanTaAnnetArbeidEtterBehandling = false,
+        kanIkkeTaAnnetArbeid = null,
+    ),
+    prognose = Prognose(
+        vilForbedreArbeidsevne = false,
+        anslattVarighetSykdom = null,
+        anslattVarighetFunksjonsnedsetting = null,
+        anslattVarighetNedsattArbeidsevne = null,
+    ),
+    arsakssammenheng = null,
+    andreOpplysninger = null,
+    kontakt = Kontakt(
+        skalKontakteBehandlendeLege = false,
+        skalKontakteArbeidsgiver = false,
+        skalKontakteBasisgruppe = false,
+        kontakteAnnenInstans = null,
+        onskesKopiAvVedtak = false,
+    ),
+    pasientenBurdeIkkeVite = null,
+    tilbakeholdInnhold = false,
+    signatur = Signatur(
+        dato = LocalDateTime.now(),
+        navn = behandlerNavn,
+        adresse = null,
+        postnummer = null,
+        poststed = null,
+        signatur = null,
+        tlfNummer = null,
+    ),
+    signaturDato = LocalDateTime.now(),
+)


### PR DESCRIPTION
Må jobbe mer med kriteriet for når en innkommende legeerklæring skal lagres. Nå lagres den bare dersom conversationRef matcher en utgående melding, men som vi har snakket opp vil dette neppe være det vanlige tilfellet.