### PR TITLE
Enable consumer for legeerklaring prod

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -70,8 +70,6 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
-    - name: TOGGLE_CONSUME_LEGEERKLARING
-      value: "true"
     - name: LEGEERKLARING_BUCKET_NAME
       value: teamsykmelding-pale2-legeerklaring-bucket-dev
     - name: PADM2_CLIENT_ID

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -70,8 +70,6 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
-    - name: TOGGLE_CONSUME_LEGEERKLARING
-      value: "false"
     - name: LEGEERKLARING_BUCKET_NAME
       value: teamsykmelding-pale2-legeerklaring-bucket-prod
     - name: PADM2_CLIENT_ID

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -108,14 +108,12 @@ fun main() {
             meldingService = meldingService,
         )
 
-        if (environment.toggleConsumeLegeerklaring) {
-            launchKafkaTaskLegeerklaring(
-                applicationState = applicationState,
-                kafkaEnvironment = environment.kafka,
-                bucketName = environment.legeerklaringBucketName,
-                database = applicationDatabase,
-            )
-        }
+        launchKafkaTaskLegeerklaring(
+            applicationState = applicationState,
+            kafkaEnvironment = environment.kafka,
+            bucketName = environment.legeerklaringBucketName,
+            database = applicationDatabase,
+        )
     }
 
     val server = embeddedServer(

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -52,7 +52,6 @@ data class Environment(
     ),
     val cronjobUbesvartMeldingIntervalDelayMinutes: Long = getEnvVar("CRONJOB_UBESVART_MELDING_INTERVAL_DELAY_MINUTES").toLong(),
     val cronjobUbesvartMeldingFristHours: Long = getEnvVar("CRONJOB_UBESVART_MELDING_FRIST_HOURS").toLong(),
-    val toggleConsumeLegeerklaring: Boolean = getEnvVar("TOGGLE_CONSUME_LEGEERKLARING").toBoolean(),
     val legeerklaringBucketName: String = getEnvVar("LEGEERKLARING_BUCKET_NAME")
 )
 

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringTask.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringTask.kt
@@ -25,8 +25,8 @@ fun launchKafkaTaskLegeerklaring(
     )
     val consumerProperties =
         kafkaConsumerConfig<KafkaLegeerklaringDeserializer>(kafkaEnvironment = kafkaEnvironment).apply {
-            this[ConsumerConfig.GROUP_ID_CONFIG] = "isbehandlerdialog-v0"
-            this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+            this[ConsumerConfig.GROUP_ID_CONFIG] = "isbehandlerdialog-v1"
+            this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
         }
 
     launchKafkaTask(

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -51,7 +51,6 @@ fun testEnvironment() = Environment(
     electorPath = "electorPath",
     cronjobUbesvartMeldingIntervalDelayMinutes = 60L * 4,
     cronjobUbesvartMeldingFristHours = 24L * 14,
-    toggleConsumeLegeerklaring = true,
     legeerklaringBucketName = "test_bucket",
 )
 


### PR DESCRIPTION
Vi kan likegodt begynne å konsumere legeerklæringer i prod med en gang. Ingenting vil bli lagret i isbehandlerdialog før vi begynner å sende forespørsler om legeerklæringer ut.