### PR TITLE
Fetch vedlegg for legeerklaring

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -72,6 +72,8 @@ spec:
       value: "production"
     - name: LEGEERKLARING_BUCKET_NAME
       value: teamsykmelding-pale2-legeerklaring-bucket-dev
+    - name: LEGEERKLARING_VEDLEGG_BUCKET_NAME
+      value: teamsykmelding-pale2-vedlegg-bucket-dev
     - name: PADM2_CLIENT_ID
       value: "dev-gcp.teamsykefravr.padm2"
     - name: PADM2_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -72,6 +72,8 @@ spec:
       value: "production"
     - name: LEGEERKLARING_BUCKET_NAME
       value: teamsykmelding-pale2-legeerklaring-bucket-prod
+    - name: LEGEERKLARING_VEDLEGG_BUCKET_NAME
+      value: teamsykmelding-pale2-vedlegg-bucket-prod
     - name: PADM2_CLIENT_ID
       value: "prod-gcp.teamsykefravr.padm2"
     - name: PADM2_URL

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -112,6 +112,7 @@ fun main() {
             applicationState = applicationState,
             kafkaEnvironment = environment.kafka,
             bucketName = environment.legeerklaringBucketName,
+            bucketNameVedlegg = environment.legeerklaringVedleggBucketName,
             database = applicationDatabase,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -53,6 +53,7 @@ data class Environment(
     val cronjobUbesvartMeldingIntervalDelayMinutes: Long = getEnvVar("CRONJOB_UBESVART_MELDING_INTERVAL_DELAY_MINUTES").toLong(),
     val cronjobUbesvartMeldingFristHours: Long = getEnvVar("CRONJOB_UBESVART_MELDING_FRIST_HOURS").toLong(),
     val legeerklaringBucketName: String = getEnvVar("LEGEERKLARING_BUCKET_NAME"),
+    val legeerklaringVedleggBucketName: String = getEnvVar("LEGEERKLARING_VEDLEGG_BUCKET_NAME"),
     val cronjobAvvistMeldingStatusIntervalDelayMinutes: Long = getEnvVar("CRONJOB_AVVIST_MELDING_STATUS_INTERVAL_DELAY_MINUTES").toLong(),
 )
 

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.kafka.KafkaConsumerService
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.melding.database.*
+import no.nav.syfo.melding.database.domain.PMelding
 import no.nav.syfo.melding.domain.MeldingType
 import no.nav.syfo.melding.kafka.domain.*
 import no.nav.syfo.util.configuredJacksonMapper
@@ -100,7 +101,10 @@ class KafkaLegeerklaringConsumer(
         if (utgaaende != null) {
             val pdfVedlegg = getPDFVedlegg(vedlegg)
             val meldingId = connection.createMeldingFraBehandler(
-                meldingFraBehandler = legeerklaring.toMeldingFraBehandler(pdfVedlegg.size),
+                meldingFraBehandler = legeerklaring.toMeldingFraBehandler(
+                    parentRef = utgaaende.uuid,
+                    antallVedlegg = pdfVedlegg.size,
+                ),
             )
             handleVedlegg(
                 meldingId = meldingId,
@@ -124,7 +128,7 @@ class KafkaLegeerklaringConsumer(
 
         if (utgaaende != null && utgaaende.tidspunkt > OffsetDateTime.now().minusMonths(2)) {
             val pdfVedlegg = getPDFVedlegg(vedlegg)
-            connection.createMeldingFraBehandler(
+            val meldingId = connection.createMeldingFraBehandler(
                 meldingFraBehandler = legeerklaring.toMeldingFraBehandler(
                     parentRef = utgaaende.uuid,
                     antallVedlegg = pdfVedlegg.size,
@@ -149,7 +153,7 @@ class KafkaLegeerklaringConsumer(
         }
 
     fun handleVedlegg(
-        meldingId: Int,
+        meldingId: PMelding.Id,
         vedlegg: List<LegeerklaringVedleggDTO>,
         connection: Connection,
     ) {

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringTask.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringTask.kt
@@ -15,6 +15,7 @@ fun launchKafkaTaskLegeerklaring(
     applicationState: ApplicationState,
     kafkaEnvironment: KafkaEnvironment,
     bucketName: String,
+    bucketNameVedlegg: String,
     database: DatabaseInterface,
 ) {
     val storage = StorageOptions.newBuilder().build().service
@@ -22,11 +23,12 @@ fun launchKafkaTaskLegeerklaring(
         database = database,
         storage = storage,
         bucketName = bucketName,
+        bucketNameVedlegg = bucketNameVedlegg,
     )
     val consumerProperties =
         kafkaConsumerConfig<KafkaLegeerklaringDeserializer>(kafkaEnvironment = kafkaEnvironment).apply {
             this[ConsumerConfig.GROUP_ID_CONFIG] = "isbehandlerdialog-v1"
-            this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
+            this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "none"
         }
 
     launchKafkaTask(

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/LegeerklaringDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/LegeerklaringDTO.kt
@@ -151,7 +151,10 @@ data class Signatur(
     val tlfNummer: String?,
 )
 
-fun LegeerklaringDTO.toMeldingFraBehandler(parentRef: UUID) =
+fun LegeerklaringDTO.toMeldingFraBehandler(
+    parentRef: UUID,
+    antallVedlegg: Int,
+) =
     MeldingFraBehandler(
         uuid = UUID.randomUUID(),
         createdAt = OffsetDateTime.now(),
@@ -176,6 +179,6 @@ fun LegeerklaringDTO.toMeldingFraBehandler(parentRef: UUID) =
         behandlerPersonIdent = PersonIdent(personNrLege),
         behandlerNavn = legeerklaering.signatur.navn,
         tekst = legeerklaering.forslagTilTiltak.tekst,
-        antallVedlegg = 0,
+        antallVedlegg = antallVedlegg,
         innkommendePublishedAt = null,
     )

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/LegeerklaringVedleggDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/LegeerklaringVedleggDTO.kt
@@ -1,0 +1,21 @@
+package no.nav.syfo.melding.kafka.legeerklaring
+
+import java.util.Base64
+
+data class LegeerklaringVedleggDTO(
+    val vedlegg: Vedlegg,
+)
+
+fun LegeerklaringVedleggDTO.getBytes() =
+    Base64.getMimeDecoder().decode(vedlegg.content.content)
+
+data class Vedlegg(
+    val content: Content,
+    val type: String,
+    val description: String,
+)
+
+data class Content(
+    val contentType: String,
+    val content: String,
+)

--- a/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
+++ b/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
@@ -1,3 +1,3 @@
 REVOKE ALL ON ALL TABLES IN SCHEMA public FROM cloudsqliamuser;
-GRANT ALL ON ALL TABLES IN SCHEMA public TO cloudsqliamuser;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO cloudsqliamuser;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO "isyfo-analyse";

--- a/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
+++ b/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
@@ -1,4 +1,3 @@
 REVOKE ALL ON ALL TABLES IN SCHEMA public FROM cloudsqliamuser;
--- touch --
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO cloudsqliamuser;
+GRANT ALL ON ALL TABLES IN SCHEMA public TO cloudsqliamuser;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO "isyfo-analyse";

--- a/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaLegeerklaringFraBehandlerConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaLegeerklaringFraBehandlerConsumerSpek.kt
@@ -8,13 +8,12 @@ import kotlinx.coroutines.runBlocking
 import no.nav.syfo.melding.database.*
 import no.nav.syfo.melding.domain.MeldingType
 import no.nav.syfo.melding.kafka.domain.*
-import no.nav.syfo.melding.kafka.legeerklaring.KafkaLegeerklaringConsumer
-import no.nav.syfo.melding.kafka.legeerklaring.LEGEERKLARING_TOPIC
+import no.nav.syfo.melding.kafka.legeerklaring.*
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.generator.*
 import no.nav.syfo.testhelper.mock.mockKafkaConsumer
 import no.nav.syfo.util.configuredJacksonMapper
-import org.amshove.kluent.shouldBe
+import org.amshove.kluent.*
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -37,6 +36,9 @@ class KafkaLegeerklaringFraBehandlerConsumerSpek : Spek({
         }
         val storage = mockk<Storage>()
         val blob = mockk<Blob>()
+        val vedleggBlob = mockk<Blob>()
+        val vedleggPdf = byteArrayOf(0x2E, 0x28)
+
         val bucketName = externalMockEnvironment.environment.legeerklaringBucketName
         val bucketNameVedlegg = externalMockEnvironment.environment.legeerklaringVedleggBucketName
 
@@ -205,7 +207,140 @@ class KafkaLegeerklaringFraBehandlerConsumerSpek : Spek({
                     vedlegg shouldBe null
                 }
 
+                it("Should store legeerklaring with vedlegg when melding recently sent to behandler") {
+                    val msgId = UUID.randomUUID().toString()
+                    val meldingTilBehandler = defaultMeldingTilBehandler
+                    val (conversationRef, _) = database.createMeldingerTilBehandler(
+                        meldingTilBehandler.copy(
+                            arbeidstakerPersonIdent = personIdent,
+                            behandlerPersonIdent = behandlerPersonIdent,
+                            behandlerNavn = behandlerNavn,
+                            type = MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING,
+                        )
+                    )
+                    val legeerklaring = generateKafkaLegeerklaringFraBehandlerDTO(
+                        behandlerPersonIdent = behandlerPersonIdent,
+                        behandlerNavn = behandlerNavn,
+                        personIdent = personIdent,
+                        msgId = msgId,
+                        conversationRef = null,
+                        parentRef = null,
+                    )
+                    val vedleggId = UUID.randomUUID().toString()
+                    val kafkaLegeerklaring = KafkaLegeerklaeringMessage(
+                        legeerklaeringObjectId = legeerklaring.msgId,
+                        validationResult = ValidationResult(Status.OK),
+                        vedlegg = listOf(vedleggId),
+                    )
+                    every { blob.getContent() } returns configuredJacksonMapper().writeValueAsBytes(legeerklaring)
+                    every { storage.get(bucketName, legeerklaring.msgId) } returns blob
+                    val mockConsumer = mockKafkaConsumer(kafkaLegeerklaring, LEGEERKLARING_TOPIC)
+                    val legeerklaringVedlegg = LegeerklaringVedleggDTO(
+                        vedlegg = Vedlegg(
+                            content = Content(
+                                contentType = "application/pdf",
+                                content = String(Base64.getMimeEncoder().encode(vedleggPdf)),
+                            ),
+                            type = "application/pdf",
+                            description = "",
+                        ),
+                    )
+                    every { vedleggBlob.getContent() } returns configuredJacksonMapper().writeValueAsBytes(legeerklaringVedlegg)
+                    every { storage.get(bucketNameVedlegg, vedleggId) } returns vedleggBlob
+
+                    runBlocking {
+                        kafkaLegeerklaringConsumer.pollAndProcessRecords(
+                            kafkaConsumer = mockConsumer,
+                        )
+                    }
+
+                    verify(exactly = 1) { mockConsumer.commitSync() }
+
+                    val pMeldingListAfter = database.getMeldingerForArbeidstaker(personIdent)
+                    pMeldingListAfter.size shouldBeEqualTo 2
+                    val pSvar = pMeldingListAfter.last()
+                    pSvar.arbeidstakerPersonIdent shouldBeEqualTo personIdent.value
+                    pSvar.innkommende shouldBe true
+                    pSvar.msgId shouldBeEqualTo msgId
+                    pSvar.behandlerPersonIdent shouldBeEqualTo behandlerPersonIdent.value
+                    pSvar.behandlerNavn shouldBeEqualTo UserConstants.BEHANDLER_NAVN
+                    pSvar.antallVedlegg shouldBeEqualTo 1
+                    pSvar.veilederIdent shouldBeEqualTo null
+                    pSvar.type shouldBeEqualTo MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING.name
+                    pSvar.conversationRef shouldBeEqualTo conversationRef
+                    pSvar.parentRef shouldBeEqualTo meldingTilBehandler.uuid
+                    val vedlegg = database.getVedlegg(pSvar.uuid, 0)
+                    vedlegg shouldNotBe null
+                    vedlegg!!.pdf shouldBeEqualTo vedleggPdf
+                }
+
                 it("Should store legeerklaring when melding sent with same conversationRef and includes parentRef") {
+                    val msgId = UUID.randomUUID().toString()
+                    val meldingTilBehandler = defaultMeldingTilBehandler
+                    val (conversationRef, _) = database.createMeldingerTilBehandler(
+                        meldingTilBehandler.copy(
+                            arbeidstakerPersonIdent = personIdent,
+                            behandlerPersonIdent = behandlerPersonIdent,
+                            behandlerNavn = behandlerNavn,
+                            type = MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING,
+                        )
+                    )
+                    val legeerklaring = generateKafkaLegeerklaringFraBehandlerDTO(
+                        behandlerPersonIdent = behandlerPersonIdent,
+                        behandlerNavn = behandlerNavn,
+                        personIdent = personIdent,
+                        msgId = msgId,
+                        conversationRef = conversationRef.toString(),
+                    )
+                    val vedleggId = UUID.randomUUID().toString()
+                    val kafkaLegeerklaring = KafkaLegeerklaeringMessage(
+                        legeerklaeringObjectId = legeerklaring.msgId,
+                        validationResult = ValidationResult(Status.OK),
+                        vedlegg = listOf(vedleggId),
+                    )
+                    val legeerklaringVedlegg = LegeerklaringVedleggDTO(
+                        vedlegg = Vedlegg(
+                            content = Content(
+                                contentType = "application/pdf",
+                                content = String(Base64.getMimeEncoder().encode(vedleggPdf)),
+                            ),
+                            type = "application/pdf",
+                            description = "",
+                        ),
+                    )
+                    every { vedleggBlob.getContent() } returns configuredJacksonMapper().writeValueAsBytes(legeerklaringVedlegg)
+                    every { storage.get(bucketNameVedlegg, vedleggId) } returns vedleggBlob
+                    every { blob.getContent() } returns configuredJacksonMapper().writeValueAsBytes(legeerklaring)
+                    every { storage.get(bucketName, legeerklaring.msgId) } returns blob
+                    val mockConsumer = mockKafkaConsumer(kafkaLegeerklaring, LEGEERKLARING_TOPIC)
+
+                    runBlocking {
+                        kafkaLegeerklaringConsumer.pollAndProcessRecords(
+                            kafkaConsumer = mockConsumer,
+                        )
+                    }
+
+                    verify(exactly = 1) { mockConsumer.commitSync() }
+
+                    val pMeldingListAfter = database.getMeldingerForArbeidstaker(personIdent)
+                    pMeldingListAfter.size shouldBeEqualTo 2
+                    val pSvar = pMeldingListAfter.last()
+                    pSvar.arbeidstakerPersonIdent shouldBeEqualTo personIdent.value
+                    pSvar.innkommende shouldBe true
+                    pSvar.msgId shouldBeEqualTo msgId
+                    pSvar.behandlerPersonIdent shouldBeEqualTo behandlerPersonIdent.value
+                    pSvar.behandlerNavn shouldBeEqualTo UserConstants.BEHANDLER_NAVN
+                    pSvar.antallVedlegg shouldBeEqualTo 1
+                    pSvar.veilederIdent shouldBeEqualTo null
+                    pSvar.type shouldBeEqualTo MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING.name
+                    pSvar.conversationRef shouldBeEqualTo conversationRef
+                    pSvar.parentRef.toString() shouldBeEqualTo legeerklaring.conversationRef?.refToParent
+                    val vedlegg = database.getVedlegg(pSvar.uuid, 0)
+                    vedlegg shouldNotBe null
+                    vedlegg!!.pdf shouldBeEqualTo vedleggPdf
+                }
+
+                it("Should store legeerklaring with vedlegg when melding sent with same conversationRef and includes parentRef") {
                     val msgId = UUID.randomUUID().toString()
                     val meldingTilBehandler = defaultMeldingTilBehandler
                     val (conversationRef, _) = database.createMeldingerTilBehandler(

--- a/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaLegeerklaringFraBehandlerConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaLegeerklaringFraBehandlerConsumerSpek.kt
@@ -38,11 +38,13 @@ class KafkaLegeerklaringFraBehandlerConsumerSpek : Spek({
         val storage = mockk<Storage>()
         val blob = mockk<Blob>()
         val bucketName = externalMockEnvironment.environment.legeerklaringBucketName
+        val bucketNameVedlegg = externalMockEnvironment.environment.legeerklaringVedleggBucketName
 
         val kafkaLegeerklaringConsumer = KafkaLegeerklaringConsumer(
             database = database,
             storage = storage,
             bucketName = bucketName,
+            bucketNameVedlegg = bucketNameVedlegg,
         )
 
         describe("Read legeerklaring sent from behandler to NAV from Kafka Topic") {

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -52,6 +52,7 @@ fun testEnvironment() = Environment(
     cronjobUbesvartMeldingIntervalDelayMinutes = 60L * 4,
     cronjobUbesvartMeldingFristHours = 24L * 14,
     legeerklaringBucketName = "test_bucket",
+    legeerklaringVedleggBucketName = "vedlegg_bucket",
     cronjobAvvistMeldingStatusIntervalDelayMinutes = 60L * 4,
 )
 


### PR DESCRIPTION
Nå klar for review. 

I tillegg bør vi vurdere å generere pdf (ved bruk av pale-2-pdfgen) og lagre det som det første vedlegget. De aller fleste mottatte legeerklæringer har ikke noe vedlegg, så det er nok den genererte pdf'en som er mest interessant.