### PR TITLE
Add manual setting of parentRef for legeerklæring-meldinger

### DIFF
--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/LegeerklaringDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/LegeerklaringDTO.kt
@@ -151,7 +151,7 @@ data class Signatur(
     val tlfNummer: String?,
 )
 
-fun LegeerklaringDTO.toMeldingFraBehandler() =
+fun LegeerklaringDTO.toMeldingFraBehandler(parentRef: UUID) =
     MeldingFraBehandler(
         uuid = UUID.randomUUID(),
         createdAt = OffsetDateTime.now(),
@@ -159,17 +159,17 @@ fun LegeerklaringDTO.toMeldingFraBehandler() =
         conversationRef = conversationRef?.let {
             try {
                 UUID.fromString(it.refToConversation)
-            } catch (exc: IllegalArgumentException) {
+            } catch (exc: Exception) {
                 UUID.randomUUID()
             }
         } ?: UUID.randomUUID(),
         parentRef = conversationRef?.let {
             try {
                 UUID.fromString(it.refToParent)
-            } catch (exc: IllegalArgumentException) {
-                null
+            } catch (exc: Exception) {
+                parentRef
             }
-        },
+        } ?: parentRef,
         msgId = msgId,
         tidspunkt = mottattDato.atZone(ZoneId.of("Europe/Oslo")).toOffsetDateTime(),
         arbeidstakerPersonIdent = PersonIdent(personNrPasient),

--- a/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiGetSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiGetSpek.kt
@@ -72,7 +72,8 @@ class MeldingApiGetSpek : Spek({
                         )
                         val (secondConversation, _) = database.createMeldingerTilBehandler(
                             meldingTilBehandler = defaultMeldingTilBehandler.copy(
-                                conversationRef = UUID.randomUUID()
+                                uuid = UUID.randomUUID(),
+                                conversationRef = UUID.randomUUID(),
                             ),
                         )
                         with(

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -48,7 +48,7 @@ fun DatabaseInterface.createMeldingerTilBehandler(
             val id = connection.createMeldingTilBehandler(
                 meldingTilBehandler = meldingTilBehandler
                     .copy(
-                        uuid = UUID.randomUUID(),
+                        uuid = if (i == 1) meldingTilBehandler.uuid else UUID.randomUUID(),
                         tekst = "${meldingTilBehandler.tekst}$i",
                     ),
                 commit = false,

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/LegeerklaringGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/LegeerklaringGenerator.kt
@@ -13,6 +13,7 @@ fun generateKafkaLegeerklaringFraBehandlerDTO(
     msgId: String = UUID.randomUUID().toString(),
     conversationRef: String? = UUID.randomUUID().toString(),
     tidspunkt: LocalDateTime = LocalDateTime.now(),
+    parentRef: String? = UUID.randomUUID().toString(),
 ) = LegeerklaringDTO(
     legeerklaering = generateLegeerklaring(
         personIdent = personIdent.value,
@@ -29,7 +30,7 @@ fun generateKafkaLegeerklaringFraBehandlerDTO(
     mottattDato = LocalDateTime.now(),
     conversationRef = conversationRef?.let {
         ConversationRef(
-            refToParent = UUID.randomUUID().toString(),
+            refToParent = parentRef,
             refToConversation = conversationRef,
         )
     },


### PR DESCRIPTION
Ser at vi i dev ofte fikk `refToParent` som null, og da ble feltet satt til null. Når vi da sendte en "nytt svar"-oppgave til `ispersonoppgave`, og den meldingen hadde en "ubesvart melding"-oppgave på seg (påminnelse), så klarte vi ikke å automatisk lukke den påminnelse-oppgaven via systemet siden den ikke ble koblet riktig mot `parentRef`.

Se logikk i `ispersonoppgave` for dette: https://github.com/navikt/ispersonoppgave/blob/f351554079b5cf88561884ec7cc8521a23508ca3/src/main/kotlin/no/nav/syfo/behandlerdialog/MeldingFraBehandlerService.kt#L37

Ser ut til å funke fint i dev ✅ `19087999648, Smekker Gapahuk` hadde en påminnelse-oppgave på seg, som ble lukket ved nytt svar nå 👍🏼