### PR TITLE
Fikser utkommentert test

### DIFF
--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
@@ -87,14 +87,13 @@ class KafkaLegeerklaringConsumer(
         conversationRef: String,
     ) {
         val arbeidstakerPersonIdent = PersonIdent(legeerklaring.personNrPasient)
-        val utgaendeMeldinger = connection.getUtgaendeMeldingerInConversation(
+        val utgaaende = connection.getUtgaendeMeldingerInConversation(
             conversationRef = UUID.fromString(conversationRef),
             arbeidstakerPersonIdent = arbeidstakerPersonIdent,
-        )
-        if (utgaendeMeldinger.isNotEmpty()) {
-            val parentRef = utgaendeMeldinger.last().uuid
+        ).lastOrNull()
+        if (utgaaende != null) {
             connection.createMeldingFraBehandler(
-                meldingFraBehandler = legeerklaring.toMeldingFraBehandler(parentRef),
+                meldingFraBehandler = legeerklaring.toMeldingFraBehandler(parentRef = utgaaende.uuid),
             )
             COUNT_KAFKA_CONSUMER_LEGEERKLARING_STORED.increment()
         }

--- a/src/test/kotlin/no/nav/syfo/melding/cronjob/AvvistMeldingCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/cronjob/AvvistMeldingCronjobSpek.kt
@@ -1,9 +1,7 @@
 package no.nav.syfo.melding.cronjob
 
 import io.ktor.server.testing.*
-import io.mockk.clearMocks
-import io.mockk.coEvery
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.melding.database.createMeldingTilBehandler
 import no.nav.syfo.melding.database.domain.PMelding
@@ -19,6 +17,7 @@ import no.nav.syfo.testhelper.generator.generateMeldingTilBehandler
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -79,9 +78,16 @@ class AvvistMeldingCronjobSpek : Spek({
                         result.updated shouldBeEqualTo 1
                     }
 
-                    val meldinger = database.getMeldingerForArbeidstaker(UserConstants.ARBEIDSTAKER_PERSONIDENT)
-                    meldinger.first().avvistPublishedAt shouldNotBeEqualTo null
-                    // TODO: Test produce
+                    val melding = database.getMeldingerForArbeidstaker(UserConstants.ARBEIDSTAKER_PERSONIDENT).first()
+                    melding.avvistPublishedAt shouldNotBeEqualTo null
+
+                    val producerRecordSlot = slot<ProducerRecord<String, KafkaMeldingDTO>>()
+                    verify(exactly = 1) {
+                        kafkaProducer.send(capture(producerRecordSlot))
+                    }
+
+                    val kafkaMeldingDTO = producerRecordSlot.captured.value()
+                    kafkaMeldingDTO.uuid shouldBeEqualTo melding.uuid.toString()
                 }
 
                 it("Will not be picked up by cronjob if no unpublished avviste meldinger") {

--- a/src/test/kotlin/no/nav/syfo/melding/cronjob/JournalforMeldingTilBehandlerCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/cronjob/JournalforMeldingTilBehandlerCronjobSpek.kt
@@ -103,7 +103,7 @@ class JournalforDialogmeldingCronjobSpek : Spek({
                     it.journalpostId shouldBeEqualTo journalpostId.toString()
                 }
 
-                coVerifyOrder {
+                coVerifyAll {
                     dokarkivClient.journalfor(expectedJournalpostRequestMeldingTilBehandler)
                     dokarkivClient.journalfor(expectedJournalpostRequestMeldingTilBehandler)
                     dokarkivClient.journalfor(expectedJournalpostRequestPaminnelse)


### PR DESCRIPTION
Endret fra coVerifyOrder til coVerifyAll siden rekkefølgen ikke er garantert. Fjernet utkommentering av test og lagt til ekstra sjekk på avvist melding som produseres til Kafka.