### PR TITLE
Improve legeerklaring metrics

### DIFF
--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringConsumer.kt
@@ -114,7 +114,7 @@ class KafkaLegeerklaringConsumer(
                 vedlegg = pdfVedlegg,
                 connection = connection,
             )
-            COUNT_KAFKA_CONSUMER_LEGEERKLARING_STORED.increment()
+            COUNT_KAFKA_CONSUMER_LEGEERKLARING_WITH_CONVREF_STORED.increment()
         }
     }
 
@@ -144,7 +144,7 @@ class KafkaLegeerklaringConsumer(
                 vedlegg = pdfVedlegg,
                 connection = connection,
             )
-            COUNT_KAFKA_CONSUMER_LEGEERKLARING_STORED.increment()
+            COUNT_KAFKA_CONSUMER_LEGEERKLARING_WITHOUT_CONVREF_STORED.increment()
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/kafka/legeerklaring/KafkaLegeerklaringMetric.kt
@@ -6,9 +6,10 @@ import no.nav.syfo.application.metric.METRICS_REGISTRY
 
 const val KAFKA_CONSUMER_LEGEERKLARING_BASE = "${METRICS_NS}_kafka_legeerklaring"
 const val KAFKA_CONSUMER_LEGEERKLARING_READ = "${KAFKA_CONSUMER_LEGEERKLARING_BASE}_read"
-const val KAFKA_CONSUMER_LEGEERKLARING_TOMBSTONE =
-    "${KAFKA_CONSUMER_LEGEERKLARING_BASE}_tombstone"
-const val KAFKA_CONSUMER_LEGEERKLARING_STORED = "${KAFKA_CONSUMER_LEGEERKLARING_BASE}_stored"
+const val KAFKA_CONSUMER_LEGEERKLARING_TOMBSTONE = "${KAFKA_CONSUMER_LEGEERKLARING_BASE}_tombstone"
+const val KAFKA_CONSUMER_LEGEERKLARING_WITH_CONVREF_STORED = "${KAFKA_CONSUMER_LEGEERKLARING_BASE}_with_convref_stored"
+const val KAFKA_CONSUMER_LEGEERKLARING_WITHOUT_CONVREF_STORED =
+    "${KAFKA_CONSUMER_LEGEERKLARING_BASE}_without_convref_stored"
 
 val COUNT_KAFKA_CONSUMER_LEGEERKLARING_READ: Counter = Counter.builder(KAFKA_CONSUMER_LEGEERKLARING_READ)
     .description("Counts the number of reads from topic - $LEGEERKLARING_TOPIC")
@@ -18,6 +19,14 @@ val COUNT_KAFKA_CONSUMER_LEGEERKLARING_TOMBSTONE: Counter = Counter.builder(KAFK
     .description("Counts the number of tombstones from topic - $LEGEERKLARING_TOPIC")
     .register(METRICS_REGISTRY)
 
-val COUNT_KAFKA_CONSUMER_LEGEERKLARING_STORED: Counter = Counter.builder(KAFKA_CONSUMER_LEGEERKLARING_STORED)
-    .description("Counts the number of stored from topic - $LEGEERKLARING_TOPIC")
-    .register(METRICS_REGISTRY)
+val COUNT_KAFKA_CONSUMER_LEGEERKLARING_WITH_CONVREF_STORED: Counter =
+    Counter.builder(KAFKA_CONSUMER_LEGEERKLARING_WITH_CONVREF_STORED)
+        .description("Counts the number of legeerklaring with conversation ref stored from topic - $LEGEERKLARING_TOPIC")
+        .register(METRICS_REGISTRY)
+
+val COUNT_KAFKA_CONSUMER_LEGEERKLARING_WITHOUT_CONVREF_STORED: Counter =
+    Counter.builder(KAFKA_CONSUMER_LEGEERKLARING_WITHOUT_CONVREF_STORED)
+        .description(
+            "Counts the number of legeerklaring without conversation ref stored from topic - $LEGEERKLARING_TOPIC"
+        )
+        .register(METRICS_REGISTRY)


### PR DESCRIPTION
Siden vi har en hypotese om at vi bare kommer til å få inn legeerklæringer uten conversationref så er det fint å telle opp de som kommer inn i to metrics, sånn at vi får vite om hypotesen stemmer.