### PR TITLE
IS-1771: Remove illegal char from melding before pdfgen

### DIFF
--- a/src/test/kotlin/no/nav/syfo/melding/domain/DocumentComponentSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/domain/DocumentComponentSpek.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.melding.domain
 
+import no.nav.syfo.client.pdfgen.sanitizeForPdfGen
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -35,6 +36,25 @@ class DocumentComponentSpek : Spek({
                 
                 
             """.trimIndent()
+        }
+    }
+    describe("sanitizeForPdfGen") {
+        it("removes illegal characters") {
+            val documentWithIllegalChar = listOf(
+                DocumentComponentDTO(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = "tittel",
+                    texts = listOf("text1\u0002dsa", "text2"),
+                )
+            )
+            val expectedDocument = listOf(
+                DocumentComponentDTO(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = "tittel",
+                    texts = listOf("text1dsa", "text2"),
+                )
+            )
+            documentWithIllegalChar.sanitizeForPdfGen() shouldBeEqualTo expectedDocument
         }
     }
 })


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Kopiert fra samme funksjonalitet i `isdialogmote` https://github.com/navikt/isdialogmote/pull/472/files
Vi har fått 6 feil i dag på pdfer som ikke har gått gjennom pga illegal char.