### PR TITLE
Handle refs that are empty strings

### DIFF
--- a/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaDialogmeldingFraBehandlerConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/kafka/KafkaDialogmeldingFraBehandlerConsumerSpek.kt
@@ -85,6 +85,30 @@ class KafkaDialogmeldingFraBehandlerConsumerSpek : Spek({
 
                     database.getMeldingerForArbeidstaker(personIdent).size shouldBeEqualTo 0
                 }
+                it("Receive dialogmelding DIALOG_SVAR with empty string as conversationRef doesn't fail") {
+                    val dialogmelding = generateDialogmeldingFraBehandlerForesporselSvarDTO().copy(
+                        conversationRef = "",
+                    )
+                    val mockConsumer = mockKafkaConsumer(dialogmelding, DIALOGMELDING_FROM_BEHANDLER_TOPIC)
+
+                    runBlocking {
+                        kafkaDialogmeldingFraBehandlerConsumer.pollAndProcessRecords(
+                            kafkaConsumer = mockConsumer,
+                        )
+                    }
+                }
+                it("Receive dialogmelding DIALOG_SVAR with empty string as parentRef doesn't fail") {
+                    val dialogmelding = generateDialogmeldingFraBehandlerForesporselSvarDTO().copy(
+                        parentRef = "",
+                    )
+                    val mockConsumer = mockKafkaConsumer(dialogmelding, DIALOGMELDING_FROM_BEHANDLER_TOPIC)
+
+                    runBlocking {
+                        kafkaDialogmeldingFraBehandlerConsumer.pollAndProcessRecords(
+                            kafkaConsumer = mockConsumer,
+                        )
+                    }
+                }
                 it("Receive dialogmelding DIALOG_NOTAT from behandler creates melding when person sykmeldt") {
                     val dialogmelding = generateDialogmeldingFraBehandlerDialogNotatDTO()
                     val mockConsumer = mockKafkaConsumer(dialogmelding, DIALOGMELDING_FROM_BEHANDLER_TOPIC)


### PR DESCRIPTION
Now it doesn't fail when trying to convert it to UUID when looking for
an outgoing message that's in the same thread as this message.
We recived a dialogmelding from behandler where conversationRef and
parentRef are empty strings, not null. Because we only check for null,
UUID from string throws an exception we don't handle, and the app
restarts.