### PR TITLE
IS-1867: Add melding uuid as eksternReferanseId to journalpostRequest

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.dokarkiv
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -17,10 +18,9 @@ import org.slf4j.LoggerFactory
 class DokarkivClient(
     private val azureAdClient: AzureAdClient,
     private val clientEnvironment: ClientEnvironment,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
     private val journalpostUrl: String = "${clientEnvironment.baseUrl}$JOURNALPOST_PATH"
-
-    private val httpClient = httpClientDefault()
 
     suspend fun journalfor(
         journalpostRequest: JournalpostRequest,

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/Dokument.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/Dokument.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.client.dokarkiv.domain
 enum class BrevkodeType(
     val value: String,
 ) {
-    FORESPORSEL_OM_PASIENT("OPPF_FORESP_OM_PAS"), // TODO: Burde vi ha en egen brevkodetype for legeerklæring?
+    FORESPORSEL_OM_PASIENT("OPPF_FORESP_OM_PAS"),
     FORESPORSEL_OM_PASIENT_PAMINNELSE("OPPF_FORESP_OM_PAS_PAM"),
     HENVENDELSE_RETUR_LEGEERKLARING("OPPF_HENV_RETUR_LEGEERKLARING"),
     HENVENDELSE_MELDING_FRA_NAV("OPPF_HENV_MELDING_FRA_NAV"),

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/JournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/JournalpostRequest.kt
@@ -47,5 +47,6 @@ data class JournalpostRequest(
     val tema: String = JournalpostTema.OPPFOLGING.value,
     val kanal: String = JournalpostKanal.HELSENETTET.value,
     val sak: Sak = Sak(),
+    val eksternReferanseId: String,
     val overstyrInnsynsregler: String? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/melding/domain/MeldingTilBehandler.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/domain/MeldingTilBehandler.kt
@@ -220,6 +220,7 @@ fun MeldingTilBehandler.toJournalpostRequest(pdf: ByteArray) =
             )
         ),
         overstyrInnsynsregler = this.createOverstyrInnsynsregler(),
+        eksternReferanseId = uuid.toString(),
     )
 
 fun MeldingTilBehandler.createTittel(): String {

--- a/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
@@ -1,0 +1,60 @@
+package no.nav.syfo.client.dokarkiv
+
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.dokarkiv.domain.BrevkodeType
+import no.nav.syfo.client.dokarkiv.domain.MeldingTittel
+import no.nav.syfo.client.dokarkiv.domain.OverstyrInnsynsregler
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.generator.journalpostRequestGenerator
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.UUID
+
+val journalpostRequest = journalpostRequestGenerator(
+    pdf = UserConstants.PDF_LEGEERKLARING,
+    brevkodeType = BrevkodeType.FORESPORSEL_OM_PASIENT,
+    tittel = MeldingTittel.DIALOGMELDING_DEFAULT.value,
+    overstyrInnsynsregler = OverstyrInnsynsregler.VISES_MASKINELT_GODKJENT.value,
+    eksternReferanseId = UUID.randomUUID().toString(),
+)
+
+class DokarkivClientSpek : Spek({
+
+    val externalMockEnvironment = ExternalMockEnvironment.instance
+    val mockHttpClient = externalMockEnvironment.mockHttpClient
+    val azureAdClient = AzureAdClient(
+        azureEnvironment = externalMockEnvironment.environment.azure,
+        httpClient = mockHttpClient,
+    )
+
+    val dokarkivClient = DokarkivClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = externalMockEnvironment.environment.clients.dokarkiv,
+        httpClient = mockHttpClient,
+    )
+
+    describe("${DokarkivClient::class.java.simpleName} journalfor") {
+        it("returns OK response when unique eksternReferanseId") {
+            val response = runBlocking {
+                dokarkivClient.journalfor(journalpostRequest = journalpostRequest)
+            }
+
+            response.shouldNotBeNull()
+        }
+
+        it("returns null response when conflicting eksternReferanseId") {
+            val journalpostRequestWithConflictingEksternReferanseId =
+                journalpostRequest.copy(eksternReferanseId = UserConstants.EXISTING_EKSTERN_REFERANSE_UUID)
+
+            val response = runBlocking {
+                dokarkivClient.journalfor(journalpostRequest = journalpostRequestWithConflictingEksternReferanseId)
+            }
+
+            response.shouldBeNull()
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -29,4 +29,6 @@ object UserConstants {
     const val HERID = 404
     const val HPRID = 1337
     const val VIRKSOMHETSNUMMER = "987654321"
+
+    val EXISTING_EKSTERN_REFERANSE_UUID = UUID.randomUUID().toString()
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
@@ -7,6 +7,7 @@ fun journalpostRequestGenerator(
     pdf: ByteArray,
     brevkodeType: BrevkodeType,
     tittel: String,
+    eksternReferanseId: String,
     overstyrInnsynsregler: String?,
 ) = JournalpostRequest(
     avsenderMottaker = AvsenderMottaker.create(
@@ -31,4 +32,5 @@ fun journalpostRequestGenerator(
         )
     ),
     overstyrInnsynsregler = overstyrInnsynsregler,
+    eksternReferanseId = eksternReferanseId,
 )

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
@@ -2,9 +2,6 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
-import io.ktor.server.application.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
 import no.nav.syfo.client.azuread.AzureAdTokenResponse
 
 fun MockRequestHandleScope.azureAdMockResponse(): HttpResponseData = respond(

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
@@ -1,0 +1,23 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.syfo.client.dokarkiv.domain.JournalpostRequest
+import no.nav.syfo.client.dokarkiv.domain.JournalpostResponse
+import no.nav.syfo.testhelper.UserConstants
+
+val response = JournalpostResponse(
+    journalpostId = 1,
+    journalpostferdigstilt = true,
+    journalstatus = "status",
+)
+
+suspend fun MockRequestHandleScope.dokarkivMockResponse(request: HttpRequestData): HttpResponseData {
+    val eksternReferanseId = request.receiveBody<JournalpostRequest>().eksternReferanseId
+
+    return when (eksternReferanseId) {
+        UserConstants.EXISTING_EKSTERN_REFERANSE_UUID -> respondError(HttpStatusCode.Conflict)
+        else -> respond(response)
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
@@ -24,6 +24,8 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
 
                 requestUrl.startsWith("/${environment.clients.oppfolgingstilfelle.baseUrl}") -> oppfolgingstilfelleClientMockResponse(request)
 
+                requestUrl.startsWith("/${environment.clients.dokarkiv.baseUrl}") -> dokarkivMockResponse(request)
+
                 else -> error("Unhandled ${request.url.encodedPath}")
             }
         }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/OppfolgingstilfelleClientMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/OppfolgingstilfelleClientMock.kt
@@ -10,8 +10,7 @@ import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import java.time.LocalDate
 
 fun MockRequestHandleScope.oppfolgingstilfelleClientMockResponse(request: HttpRequestData): HttpResponseData {
-    val requestPersonIdent = request.headers[NAV_PERSONIDENT_HEADER]
-    return when (requestPersonIdent) {
+    return when (val requestPersonIdent = request.headers[NAV_PERSONIDENT_HEADER]) {
         null -> respond(HttpStatusCode.BadRequest)
         UserConstants.ARBEIDSTAKER_PERSONIDENT.value -> respond(
             OppfolgingstilfellePersonDTO(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Feltet `eksternReferanseId` vil bli påkrevd i dokarkiv-tjenesten `opprettJournalpost` så legger på uuid fra melding der.