### PR TITLE
IS-2270: Handle 409 from dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -39,7 +39,15 @@ class DokarkivClient(
                 COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS.increment()
                 journalpostResponse
             } catch (e: ClientRequestException) {
-                handleUnexpectedResponseException(e.response, e.message)
+                if (e.response.status == HttpStatusCode.Conflict) {
+                    val journalpostResponse = e.response.body<JournalpostResponse>()
+                    log.warn("Journalpost med id ${journalpostResponse.journalpostId} lagret fra før (409 Conflict)")
+                    COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT.increment()
+                    journalpostResponse
+                } else {
+                    handleUnexpectedResponseException(e.response, e.message)
+                    throw e
+                }
             } catch (e: ServerResponseException) {
                 handleUnexpectedResponseException(e.response, e.message)
             }

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivMetric.kt
@@ -9,6 +9,7 @@ const val CALL_DOKARKIV_BASE = "${METRICS_NS}_call_dokarkiv"
 const val CALL_DOKARKIV_JOURNALPOST_BASE = "${CALL_DOKARKIV_BASE}_journalpost"
 const val CALL_DOKARKIV_JOURNALPOST_SUCCESS = "${CALL_DOKARKIV_JOURNALPOST_BASE}_success_count"
 const val CALL_DOKARKIV_JOURNALPOST_FAIL = "${CALL_DOKARKIV_JOURNALPOST_BASE}_fail_count"
+const val CALL_DOKARKIV_JOURNALPOST_CONFLICT = "${CALL_DOKARKIV_JOURNALPOST_BASE}_conflict_count"
 
 val COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS: Counter = Counter
     .builder(CALL_DOKARKIV_JOURNALPOST_SUCCESS)
@@ -17,4 +18,8 @@ val COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS: Counter = Counter
 val COUNT_CALL_DOKARKIV_JOURNALPOST_FAIL: Counter = Counter
     .builder(CALL_DOKARKIV_JOURNALPOST_FAIL)
     .description("Counts the number of failed calls to Dokarkiv - Journalpost")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT: Counter = Counter
+    .builder(CALL_DOKARKIV_JOURNALPOST_CONFLICT)
+    .description("Counts the number of calls to Dokarkiv - Journalpost resulting in 409 Conflict")
     .register(METRICS_REGISTRY)

--- a/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
@@ -8,8 +8,8 @@ import no.nav.syfo.client.dokarkiv.domain.OverstyrInnsynsregler
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.generator.journalpostRequestGenerator
-import org.amshove.kluent.shouldBeNull
-import org.amshove.kluent.shouldNotBeNull
+import no.nav.syfo.testhelper.mock.conflictResponse
+import org.amshove.kluent.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.util.UUID
@@ -46,7 +46,7 @@ class DokarkivClientSpek : Spek({
             response.shouldNotBeNull()
         }
 
-        it("returns null response when conflicting eksternReferanseId") {
+        it("returns existing journalpostResponse when conflicting eksternReferanseId") {
             val journalpostRequestWithConflictingEksternReferanseId =
                 journalpostRequest.copy(eksternReferanseId = UserConstants.EXISTING_EKSTERN_REFERANSE_UUID)
 
@@ -54,7 +54,8 @@ class DokarkivClientSpek : Spek({
                 dokarkivClient.journalfor(journalpostRequest = journalpostRequestWithConflictingEksternReferanseId)
             }
 
-            response.shouldBeNull()
+            response?.journalpostId shouldBeEqualTo conflictResponse.journalpostId
+            response?.journalstatus shouldBeEqualTo conflictResponse.journalstatus
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
@@ -12,12 +12,17 @@ val response = JournalpostResponse(
     journalpostferdigstilt = true,
     journalstatus = "status",
 )
+val conflictResponse = JournalpostResponse(
+    journalpostId = 2,
+    journalpostferdigstilt = true,
+    journalstatus = "conflict",
+)
 
 suspend fun MockRequestHandleScope.dokarkivMockResponse(request: HttpRequestData): HttpResponseData {
     val eksternReferanseId = request.receiveBody<JournalpostRequest>().eksternReferanseId
 
     return when (eksternReferanseId) {
-        UserConstants.EXISTING_EKSTERN_REFERANSE_UUID -> respondError(HttpStatusCode.Conflict)
+        UserConstants.EXISTING_EKSTERN_REFERANSE_UUID -> respond(conflictResponse, HttpStatusCode.Conflict)
         else -> respond(response)
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockUtils.kt
@@ -7,10 +7,10 @@ import no.nav.syfo.util.configuredJacksonMapper
 
 val mapper = configuredJacksonMapper()
 
-fun <T> MockRequestHandleScope.respond(body: T): HttpResponseData =
+fun <T> MockRequestHandleScope.respond(body: T, statusCode: HttpStatusCode = HttpStatusCode.OK): HttpResponseData =
     respond(
         mapper.writeValueAsString(body),
-        HttpStatusCode.OK,
+        statusCode,
         headersOf(HttpHeaders.ContentType, "application/json")
     )
 


### PR DESCRIPTION
Vi får 409 fra Dokarkiv når det allerede er oppretet en journalpost med den gitte IDen, da kan vi håndtere det ved å lagre journalpostIDen vi får fra responsen.
Plagiat av https://github.com/navikt/isaktivitetskrav/pull/213