### PR TITLE
IS-2343: Migrate to using ispdfgen for pdf generation

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -48,7 +48,7 @@ spec:
       external:
         - host: "dokarkiv.dev-fss-pub.nais.io"
       rules:
-        - application: dialogmeldingpdfgen
+        - application: ispdfgen
         - application: padm2
         - application: istilgangskontroll
         - application: isoppfolgingstilfelle

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -48,7 +48,7 @@ spec:
       external:
         - host: "dokarkiv.prod-fss-pub.nais.io"
       rules:
-        - application: dialogmeldingpdfgen
+        - application: ispdfgen
         - application: padm2
         - application: isoppfolgingstilfelle
         - application: istilgangskontroll

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -44,7 +44,7 @@ data class Environment(
             clientId = getEnvVar("ISTILGANGSKONTROLL_CLIENT_ID"),
         ),
         dialogmeldingpdfgen = OpenClientEnvironment(
-            baseUrl = "http://dialogmeldingpdfgen",
+            baseUrl = "http://ispdfgen",
         ),
         legeerklaringpdfgen = OpenClientEnvironment(
             baseUrl = "http://pale-2-pdfgen.teamsykmelding",

--- a/src/main/kotlin/no/nav/syfo/melding/MeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/melding/MeldingService.kt
@@ -72,7 +72,7 @@ class MeldingService(
 
     private fun getBehandlerRefForConversation(
         meldingFraBehandler: MeldingFraBehandler,
-        personIdent: PersonIdent
+        personIdent: PersonIdent,
     ): UUID? {
         val behandlerRef = getUtgaendeMeldingerInConversation(
             conversationRef = meldingFraBehandler.conversationRef,
@@ -120,7 +120,7 @@ class MeldingService(
         callId: String,
         meldingUuid: UUID,
         veilederIdent: String,
-        document: List<DocumentComponentDTO>
+        document: List<DocumentComponentDTO>,
     ) {
         val opprinneligMelding = getMeldingTilBehandler(meldingUuid = meldingUuid)
             ?: throw IllegalArgumentException("Failed to create påminnelse: Melding with uuid $meldingUuid does not exist")
@@ -166,42 +166,14 @@ class MeldingService(
 
     private suspend fun createPdf(
         callId: String,
-        meldingTilBehandler: MeldingTilBehandler
-    ): ByteArray {
-        return when (meldingTilBehandler.type) {
-            MeldingType.FORESPORSEL_PASIENT_TILLEGGSOPPLYSNINGER -> pdfgenClient.generateForesporselOmPasientTilleggsopplysinger(
-                callId = callId,
-                mottakerNavn = meldingTilBehandler.behandlerNavn ?: "",
-                documentComponentDTOList = meldingTilBehandler.document
-            )
-
-            MeldingType.FORESPORSEL_PASIENT_PAMINNELSE -> pdfgenClient.generateForesporselOmPasientPaminnelse(
-                callId = callId,
-                mottakerNavn = meldingTilBehandler.behandlerNavn ?: "",
-                documentComponentDTOList = meldingTilBehandler.document
-            )
-
-            MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING -> pdfgenClient.generateForesporselOmPasientLegeerklaring(
-                callId = callId,
-                mottakerNavn = meldingTilBehandler.behandlerNavn ?: "",
-                documentComponentDTOList = meldingTilBehandler.document
-            )
-
-            MeldingType.HENVENDELSE_RETUR_LEGEERKLARING -> pdfgenClient.generateReturAvLegeerklaring(
-                callId = callId,
-                mottakerNavn = meldingTilBehandler.behandlerNavn ?: "",
-                documentComponentDTOList = meldingTilBehandler.document,
-            )
-
-            MeldingType.HENVENDELSE_MELDING_FRA_NAV -> pdfgenClient.generateMeldingFraNav(
-                callId = callId,
-                mottakerNavn = meldingTilBehandler.behandlerNavn ?: "",
-                documentComponentDTOList = meldingTilBehandler.document,
-            )
-            MeldingType.HENVENDELSE_MELDING_TIL_NAV ->
-                throw RuntimeException("Should only be used for incoming messages")
-        } ?: throw RuntimeException("Failed to request PDF - ${meldingTilBehandler.type}")
-    }
+        meldingTilBehandler: MeldingTilBehandler,
+    ): ByteArray =
+        pdfgenClient.generateDialogPdf(
+            callId = callId,
+            mottakerNavn = meldingTilBehandler.behandlerNavn ?: "",
+            documentComponentDTOList = meldingTilBehandler.document,
+            meldingType = meldingTilBehandler.type,
+        ) ?: throw RuntimeException("Failed to request PDF - ${meldingTilBehandler.type}")
 
     private fun createMeldingTilBehandlerAndSendDialogmeldingBestilling(
         meldingTilBehandler: MeldingTilBehandler,

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdfGenClientMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdfGenClientMock.kt
@@ -2,28 +2,28 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
-import no.nav.syfo.client.pdfgen.PdfGenClient
 import no.nav.syfo.testhelper.UserConstants
 
 fun MockRequestHandleScope.pdfGenClientMockResponse(request: HttpRequestData): HttpResponseData {
     val requestUrl = request.url.encodedPath
+    val apiBasePath = "/api/v1/genpdf/isbehandlerdialog"
     return when {
-        requestUrl.endsWith(PdfGenClient.Companion.FORESPORSEL_OM_PASIENT_TILLEGGSOPPLYSNINGER_PATH) -> {
+        requestUrl.endsWith("$apiBasePath/foresporselompasient-tilleggsopplysninger") -> {
             respond(content = UserConstants.PDF_FORESPORSEL_OM_PASIENT_TILLEGGSOPPLYSNINGER)
         }
-        requestUrl.endsWith(PdfGenClient.Companion.FORESPORSEL_OM_PASIENT_LEGEERKLARING_PATH) -> {
+        requestUrl.endsWith("$apiBasePath/foresporselompasient-legeerklaring") -> {
             respond(content = UserConstants.PDF_FORESPORSEL_OM_PASIENT_LEGEERKLARING)
         }
-        requestUrl.endsWith(PdfGenClient.Companion.FORESPORSEL_OM_PASIENT_PAMINNELSE_PATH) -> {
+        requestUrl.endsWith("$apiBasePath/foresporselompasient-paminnelse") -> {
             respond(content = UserConstants.PDF_FORESPORSEL_OM_PASIENT_PAMINNELSE)
         }
-        requestUrl.endsWith(PdfGenClient.Companion.LEGEERKLARING_PATH) -> {
+        requestUrl.endsWith("/api/v1/genpdf/pale-2/pale-2") -> {
             respond(content = UserConstants.PDF_LEGEERKLARING)
         }
-        requestUrl.endsWith(PdfGenClient.Companion.RETUR_LEGEERKLARING_PATH) -> {
+        requestUrl.endsWith("$apiBasePath/henvendelse-retur-legeerklaring") -> {
             respond(content = UserConstants.PDF_RETUR_LEGEERKLARING)
         }
-        requestUrl.endsWith(PdfGenClient.Companion.HENVENDELSE_MELDING_FRA_NAV_PATH) -> {
+        requestUrl.endsWith("$apiBasePath/henvendelse-meldingfranav") -> {
             respond(content = UserConstants.PDF_HENVENDELSE_MELDING_FRA_NAV)
         }
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Endrer til å bruke `ispdfgen` i stedet for `dialogmeldingpdfen`.
- Se [tilhørende PR](https://github.com/navikt/ispdfgen/pull/10) i `ispdfgen`

- [x] Testet i dev