### PR TITLE
IS-3758: Add write access check to endpoints

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/VeilederTilgangskontrollCheck.kt
+++ b/src/main/kotlin/no/nav/syfo/api/VeilederTilgangskontrollCheck.kt
@@ -10,17 +10,26 @@ import no.nav.syfo.util.getCallId
 suspend fun ApplicationCall.checkVeilederTilgang(
     action: String,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
-    personIdent: PersonIdent,
+    personident: PersonIdent,
+    requiresWriteAccess: Boolean = false,
 ) {
     val callId = getCallId()
     val token = getBearerHeader()
         ?: throw IllegalArgumentException("Failed to complete the following action: $action. No Authorization header supplied")
 
-    val hasAccess = veilederTilgangskontrollClient.hasAccess(
-        callId = callId,
-        personIdent = personIdent,
-        token = token,
-    )
+    val hasAccess = if (requiresWriteAccess) {
+        veilederTilgangskontrollClient.hasWriteAccess(
+            callId = callId,
+            personident = personident,
+            token = token,
+        )
+    } else {
+        veilederTilgangskontrollClient.hasAccess(
+            callId = callId,
+            personident = personident,
+            token = token,
+        )
+    }
     if (!hasAccess) {
         throw ForbiddenAccessVeilederException(
             action = action,

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/MeldingApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/MeldingApi.kt
@@ -16,7 +16,7 @@ import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrol
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.getCallId
 import no.nav.syfo.util.getNAVIdent
-import no.nav.syfo.util.getPersonIdent
+import no.nav.syfo.util.getPersonident
 import java.util.*
 
 const val meldingApiBasePath = "/api/internad/v1/melding"
@@ -31,13 +31,13 @@ fun Route.registerMeldingApi(
 ) {
     route(meldingApiBasePath) {
         get {
-            val personIdent = call.personIdent()
+            val personident = call.personident()
             call.checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
-                personIdent = personIdent
+                personident = personident
             )
-            val conversations = meldingService.getConversations(personIdent)
+            val conversations = meldingService.getConversations(personident)
 
             call.respond(
                 MeldingResponseDTO(conversations = conversations)
@@ -49,11 +49,11 @@ fun Route.registerMeldingApi(
             val vedleggNumberString = call.parameters[vedleggNumber]
                 ?: throw IllegalArgumentException("Missing value for vedleggNumber")
 
-            val personIdent = meldingService.getArbeidstakerPersonIdentForMelding(meldingUuid)
+            val personident = meldingService.getArbeidstakerPersonIdentForMelding(meldingUuid)
             call.checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
-                personIdent = personIdent
+                personident = personident
             )
 
             val pdfContent = meldingService.getVedlegg(
@@ -68,12 +68,13 @@ fun Route.registerMeldingApi(
         }
 
         post {
-            val personIdent = call.personIdent()
+            val personident = call.personident()
             val veilederIdent = call.getNAVIdent()
             call.checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
-                personIdent = personIdent
+                personident = personident,
+                requiresWriteAccess = true,
             )
             val requestDTO = call.receive<MeldingTilBehandlerRequestDTO>()
 
@@ -81,19 +82,20 @@ fun Route.registerMeldingApi(
                 requestDTO = requestDTO,
                 callId = getCallId(),
                 veilederIdent = veilederIdent,
-                personIdent = personIdent,
+                personIdent = personident,
             )
 
             call.respond(HttpStatusCode.OK)
         }
 
         post("/{$uuid}/paminnelse") {
-            val personIdent = call.personIdent()
+            val personident = call.personident()
             val veilederIdent = call.getNAVIdent()
             call.checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
-                personIdent = personIdent
+                personident = personident,
+                requiresWriteAccess = true,
             )
 
             val meldingUuid = call.meldingUuid()
@@ -110,12 +112,13 @@ fun Route.registerMeldingApi(
         }
 
         post("/{$uuid}/retur") {
-            val personIdent = call.personIdent()
+            val personident = call.personident()
             val veilederIdent = call.getNAVIdent()
             call.checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
-                personIdent = personIdent
+                personident = personident,
+                requiresWriteAccess = true,
             )
 
             val meldingUuid = call.meldingUuid()
@@ -137,5 +140,5 @@ fun Route.registerMeldingApi(
 private fun ApplicationCall.meldingUuid(): UUID = UUID.fromString(this.parameters[uuid])
     ?: throw IllegalArgumentException("Missing value for melding uuid")
 
-private fun ApplicationCall.personIdent(): PersonIdent = this.getPersonIdent()
+private fun ApplicationCall.personident(): PersonIdent = this.getPersonident()
     ?: throw IllegalArgumentException("Failed to $API_ACTION: No $NAV_PERSONIDENT_HEADER supplied in request header")

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
@@ -2,4 +2,6 @@ package no.nav.syfo.infrastructure.client.veiledertilgang
 
 data class Tilgang(
     val erGodkjent: Boolean,
+    val erAvslatt: Boolean = false,
+    val fullTilgang: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -4,9 +4,7 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.http.*
-import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.infrastructure.client.ClientEnvironment
 import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
@@ -23,7 +21,15 @@ class VeilederTilgangskontrollClient(
 ) {
     private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_PATH"
 
-    suspend fun hasAccess(callId: String, personIdent: PersonIdent, token: String): Boolean {
+    suspend fun hasAccess(callId: String, personident: PersonIdent, token: String): Boolean =
+        getTilgang(callId, personident, token)?.erGodkjent ?: false
+
+    suspend fun hasWriteAccess(callId: String, personident: PersonIdent, token: String): Boolean =
+        getTilgang(callId, personident, token)?.let {
+            it.erGodkjent && it.fullTilgang
+        } ?: false
+
+    private suspend fun getTilgang(callId: String, personident: PersonIdent, token: String): Tilgang? {
         val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
             scopeClientId = clientEnvironment.clientId,
             token = token,
@@ -32,32 +38,21 @@ class VeilederTilgangskontrollClient(
         return try {
             val tilgang = httpClient.get(tilgangskontrollPersonUrl) {
                 header(HttpHeaders.Authorization, bearerHeader(onBehalfOfToken))
-                header(NAV_PERSONIDENT_HEADER, personIdent.value)
+                header(NAV_PERSONIDENT_HEADER, personident.value)
                 header(NAV_CALL_ID_HEADER, callId)
                 accept(ContentType.Application.Json)
             }
             COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS.increment()
-            tilgang.body<Tilgang>().erGodkjent
+            tilgang.body<Tilgang>()
         } catch (e: ResponseException) {
             if (e.response.status == HttpStatusCode.Forbidden) {
                 COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN.increment()
             } else {
-                handleUnexpectedResponseException(e.response, callId)
+                log.error("Error while requesting access to person from istilgangskontroll with statuscode: ${e.response.status.value}, callId: $callId")
+                COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL.increment()
             }
-            false
+            null
         }
-    }
-
-    private fun handleUnexpectedResponseException(
-        response: HttpResponse,
-        callId: String,
-    ) {
-        log.error(
-            "Error while requesting access to person from istilgangskontroll with {}, {}",
-            StructuredArguments.keyValue("statusCode", response.status.value.toString()),
-            StructuredArguments.keyValue("callId", callId)
-        )
-        COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL.increment()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -8,9 +8,12 @@ import no.nav.syfo.domain.PersonIdent
 const val JWT_CLAIM_AZP = "azp"
 const val JWT_CLAIM_NAVIDENT = "NAVident"
 
+fun getNavIdentFromToken(token: String): String? =
+    runCatching { JWT.decode(token).claims[JWT_CLAIM_NAVIDENT]?.asString() }.getOrNull()
+
 fun ApplicationCall.getCallId(): String = this.request.headers[NAV_CALL_ID_HEADER].toString()
 
-fun ApplicationCall.getPersonIdent(): PersonIdent? =
+fun ApplicationCall.getPersonident(): PersonIdent? =
     this.request.headers[NAV_PERSONIDENT_HEADER]?.let { PersonIdent(it) }
 
 fun ApplicationCall.getConsumerClientId(): String? =
@@ -20,8 +23,7 @@ fun ApplicationCall.getConsumerClientId(): String? =
 
 fun ApplicationCall.getNAVIdent(): String {
     val token = getBearerHeader() ?: throw Error("No Authorization header supplied")
-    return JWT.decode(token).claims[JWT_CLAIM_NAVIDENT]?.asString()
-        ?: throw Error("Missing NAVident in private claims")
+    return getNavIdentFromToken(token) ?: throw Error("Missing NAVident in private claims")
 }
 
 fun ApplicationCall.getBearerHeader(): String? =

--- a/src/test/kotlin/no/nav/syfo/infrastructure/client/VeilederTilgangskontrollClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/client/VeilederTilgangskontrollClientTest.kt
@@ -1,0 +1,126 @@
+package no.nav.syfo.infrastructure.client
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
+import no.nav.syfo.infrastructure.client.azuread.AzureAdToken
+import no.nav.syfo.infrastructure.client.veiledertilgang.Tilgang
+import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.mock.respond
+import no.nav.syfo.testhelper.testEnvironment
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class VeilederTilgangskontrollClientTest {
+    private val token = "token"
+    private val oboToken = "obo-token"
+    private val callId = "call-id"
+    private val personident = UserConstants.ARBEIDSTAKER_PERSONIDENT
+    private val azureAdClient = mockk<AzureAdClient>()
+
+    @BeforeEach
+    fun setup() {
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(any(), any())
+        } returns AzureAdToken(
+            accessToken = oboToken,
+            expires = LocalDateTime.now().plusHours(1),
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `hasAccess and hasWriteAccess returns false when tilgang is not approved`() {
+        val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personident, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess and hasWriteAccess returns true when tilgang to person is approved and user has fullTilgang`() {
+        val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = true))
+
+        runBlocking {
+            assertTrue(client.hasAccess(callId, personident, token))
+            assertTrue(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess returns true and hasWriteAccess returns false when tilgang to person is approved but user does not have fullTilgang`() {
+        val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = false))
+
+        runBlocking {
+            assertTrue(client.hasAccess(callId, personident, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess and hasWriteAccess returns false on unexpected response`() {
+        val client = createMockClientForResponse(status = HttpStatusCode.InternalServerError)
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personident, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess throws when obo token request fails`() {
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(any(), any())
+        } returns null
+
+        val client = createMockClientForResponse()
+
+        assertThrows(RuntimeException::class.java) {
+            runBlocking {
+                client.hasAccess(callId, personident, token)
+            }
+        }
+    }
+
+    /**
+     * Create mock veilederTilgangkontrollClient for a specific response DTO from istilgangskontroll.
+     */
+    private fun createMockClientForResponse(
+        tilgang: Tilgang = Tilgang(erGodkjent = true),
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): VeilederTilgangskontrollClient {
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler {
+                    if (status == HttpStatusCode.OK) {
+                        respond(tilgang, status)
+                    } else {
+                        respondError(status)
+                    }
+                }
+            }
+        }
+
+        return VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = testEnvironment().clients.istilgangskontroll,
+            httpClient = httpClient,
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiPostTest.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiPostTest.kt
@@ -36,19 +36,15 @@ import kotlin.test.assertNull
 class MeldingApiPostTest {
 
     private val externalMockEnvironment = ExternalMockEnvironment.instance
-    private val database = ExternalMockEnvironment.instance.database
-    private val meldingRepository = ExternalMockEnvironment.instance.meldingRepository
+    private val database = externalMockEnvironment.database
+    private val meldingRepository = externalMockEnvironment.meldingRepository
     private val kafkaProducer = mockk<KafkaProducer<String, DialogmeldingBestillingDTO>>()
     private val dialogmeldingBestillingProducer = DialogmeldingBestillingProducer(
         dialogmeldingBestillingKafkaProducer = kafkaProducer,
     )
 
     private val apiUrl = meldingApiBasePath
-    private val validToken = generateJWT(
-        audience = externalMockEnvironment.environment.azure.appClientId,
-        issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
-        navIdent = UserConstants.VEILEDER_IDENT,
-    )
+    private val validToken = tokenForVeilederWithFullTilgang
     private val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
     private val veilederIdent = UserConstants.VEILEDER_IDENT
 
@@ -162,6 +158,11 @@ class MeldingApiPostTest {
             @Test
             fun `returns status BadRequest if no NAV_PERSONIDENT_HEADER is supplied`() {
                 testMissingPersonIdent(paminnelseApiUrl, validToken, HttpMethod.Post)
+            }
+
+            @Test
+            fun `returns status Forbidden if denied write access`() {
+                testDeniedWriteAccess(paminnelseApiUrl)
             }
 
             @Test
@@ -534,6 +535,11 @@ class MeldingApiPostTest {
             }
 
             @Test
+            fun `returns status Forbidden if denied write access`() {
+                testDeniedWriteAccess(apiUrl)
+            }
+
+            @Test
             fun `returns status BadRequest if NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied`() {
                 testInvalidPersonIdent(apiUrl, validToken, HttpMethod.Post)
             }
@@ -645,6 +651,11 @@ class MeldingApiPostTest {
             @Test
             fun `returns status BadRequest if no NAV_PERSONIDENT_HEADER is supplied`() {
                 testMissingPersonIdent(returApiUrl, validToken, HttpMethod.Post)
+            }
+
+            @Test
+            fun `returns status Forbidden if denied write access`() {
+                testDeniedWriteAccess(returApiUrl)
             }
 
             @Test

--- a/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiTestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiTestUtils.kt
@@ -10,10 +10,25 @@ import io.mockk.mockk
 import no.nav.syfo.infrastructure.kafka.producer.DialogmeldingBestillingProducer
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.generateJWT
 import no.nav.syfo.testhelper.testApiModule
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.configure
 import kotlin.test.assertEquals
+
+private val externalMockEnvironment = ExternalMockEnvironment.instance
+
+val tokenForVeilederWithFullTilgang: String = generateJWT(
+    audience = externalMockEnvironment.environment.azure.appClientId,
+    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+    navIdent = UserConstants.VEILEDER_IDENT,
+)
+
+val tokenForVeilederWithNoWriteTilgang: String = generateJWT(
+    audience = externalMockEnvironment.environment.azure.appClientId,
+    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+    navIdent = UserConstants.VEILEDER_IDENT_NO_WRITE_ACCESS,
+)
 
 fun ApplicationTestBuilder.setupApiAndClient(dialogmeldingBestillingProducer: DialogmeldingBestillingProducer = mockk()): HttpClient {
     application {
@@ -98,6 +113,19 @@ fun testDeniedPersonAccess(
                 bearerAuth(validToken)
                 header(NAV_PERSONIDENT_HEADER, UserConstants.PERSONIDENT_VEILEDER_NO_ACCESS.value)
             }
+        }
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+}
+
+fun testDeniedWriteAccess(
+    url: String,
+) {
+    testApplication {
+        val client = setupApiAndClient()
+        val response = client.post(url) {
+            bearerAuth(tokenForVeilederWithNoWriteTilgang)
+            header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
         }
         assertEquals(HttpStatusCode.Forbidden, response.status)
     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -19,6 +19,7 @@ object UserConstants {
     var PDF_HENVENDELSE_MELDING_FRA_NAV = byteArrayOf(0x2E, 103)
 
     const val VEILEDER_IDENT = "Z999999"
+    const val VEILEDER_IDENT_NO_WRITE_ACCESS = "Z888888"
 
     val MSG_ID_WITH_VEDLEGG = UUID.randomUUID()
     val VEDLEGG_BYTEARRAY = byteArrayOf(0x2E, 0x28)

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
@@ -2,12 +2,16 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
 import no.nav.syfo.infrastructure.client.azuread.AzureAdTokenResponse
 
-fun MockRequestHandleScope.azureAdMockResponse(): HttpResponseData = respond(
-    AzureAdTokenResponse(
-        access_token = "token",
-        expires_in = 3600,
-        token_type = "type",
+fun MockRequestHandleScope.azureAdMockResponse(request: HttpRequestData): HttpResponseData {
+    val assertionToken = (request.body as? FormDataContent)?.formData?.get("assertion")
+    return respond(
+        AzureAdTokenResponse(
+            access_token = assertionToken ?: "token",
+            expires_in = 3600,
+            token_type = "type",
+        )
     )
-)
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
@@ -12,7 +12,7 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
             val requestUrl = request.url.encodedPath
             when {
                 requestUrl == "/${environment.azure.openidConfigTokenEndpoint}" ->
-                    azureAdMockResponse()
+                    azureAdMockResponse(request)
 
                 requestUrl.startsWith("/${environment.clients.istilgangskontroll.baseUrl}") ->
                     tilgangskontrollMockResponse(request)

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/TilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/TilgangskontrollMock.kt
@@ -2,13 +2,20 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import no.nav.syfo.infrastructure.client.veiledertilgang.Tilgang
 import no.nav.syfo.testhelper.UserConstants.PERSONIDENT_VEILEDER_NO_ACCESS
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_WRITE_ACCESS
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.getNavIdentFromToken
+
+private fun HttpRequestData.navIdent(): String? =
+    headers[HttpHeaders.Authorization]
+        ?.removePrefix("Bearer ")
+        ?.let { getNavIdentFromToken(it) }
 
 fun MockRequestHandleScope.tilgangskontrollMockResponse(request: HttpRequestData): HttpResponseData {
-    return when (request.headers[NAV_PERSONIDENT_HEADER]) {
-        PERSONIDENT_VEILEDER_NO_ACCESS.value -> respond(Tilgang(erGodkjent = false))
-        else -> respond(Tilgang(erGodkjent = true))
-    }
+    val erGodkjent = request.headers[NAV_PERSONIDENT_HEADER] != PERSONIDENT_VEILEDER_NO_ACCESS.value
+    val fullTilgang = request.navIdent() != VEILEDER_IDENT_NO_WRITE_ACCESS
+    return respond(Tilgang(erGodkjent = erGodkjent, fullTilgang = fullTilgang))
 }


### PR DESCRIPTION
Denne endringen innfører krav om skrivetilgang (fullTilgang) for skriveoperasjoner i API-et, mens lesetilgang for GET-endepunkter er uendret.

- Tilgangskontroll er utvidet med egen sjekk for skrivetilgang og brukt på POST-endepunktene i MeldingApi.
- Testmocker og tester er oppdatert, inkludert 403-tester når veileder mangler skrivetilgang.

- [x] teste i dev