### PR TITLE
IS-3904: Bruke ispdfgen for legeerklaring

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -53,8 +53,6 @@ spec:
         - application: padm2
         - application: istilgangskontroll
         - application: isoppfolgingstilfelle
-        - application: pale-2-pdfgenrs
-          namespace: teamsykmelding
   gcp:
     sqlInstances:
       - type: POSTGRES_17

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -53,8 +53,6 @@ spec:
         - application: padm2
         - application: isoppfolgingstilfelle
         - application: istilgangskontroll
-        - application: pale-2-pdfgenrs
-          namespace: teamsykmelding
   gcp:
     sqlInstances:
       - type: POSTGRES_17

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -62,7 +62,6 @@ fun main() {
     )
     val pdfgenClient = PdfGenClient(
         pdfGenBaseUrl = environment.clients.dialogmeldingpdfgen.baseUrl,
-        legeerklaringPdfGenBaseUrl = environment.clients.legeerklaringpdfgen.baseUrl,
     )
 
     lateinit var meldingService: MeldingService

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -48,9 +48,6 @@ data class Environment(
         dialogmeldingpdfgen = OpenClientEnvironment(
             baseUrl = "http://ispdfgen",
         ),
-        legeerklaringpdfgen = OpenClientEnvironment(
-            baseUrl = "http://pale-2-pdfgenrs.teamsykmelding",
-        ),
         dokarkiv = ClientEnvironment(
             baseUrl = getEnvVar("DOKARKIV_URL"),
             clientId = getEnvVar("DOKARKIV_CLIENT_ID"),

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/ClientsEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/ClientsEnvironment.kt
@@ -4,7 +4,6 @@ data class ClientsEnvironment(
     val padm2: ClientEnvironment,
     val istilgangskontroll: ClientEnvironment,
     val dialogmeldingpdfgen: OpenClientEnvironment,
-    val legeerklaringpdfgen: OpenClientEnvironment,
     val dokarkiv: ClientEnvironment,
     val oppfolgingstilfelle: ClientEnvironment,
     val dialogmelding: ClientEnvironment,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/pdfgen/PdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/pdfgen/PdfGenClient.kt
@@ -31,7 +31,6 @@ private val mapper = configuredJacksonMapper()
 
 class PdfGenClient(
     private val pdfGenBaseUrl: String,
-    private val legeerklaringPdfGenBaseUrl: String,
     private val httpClient: HttpClient = httpClientDefault(),
 ) : IPdfGenClient {
 
@@ -65,7 +64,7 @@ class PdfGenClient(
                 validationResult = ValidationResult(Status.OK),
                 mottattDato = legeerklaringDTO.mottattDato,
             ),
-            pdfUrl = legeerklaringPdfGenBaseUrl + LEGEERKLARING_URL,
+            pdfUrl = pdfGenBaseUrl + LEGEERKLARING_URL,
         )
 
     private suspend fun getPdf(
@@ -137,7 +136,7 @@ class PdfGenClient(
         private const val FORESPORSEL_OM_PASIENT_PAMINNELSE_URL = "$API_BASE_PATH/foresporselompasient-paminnelse"
         private const val RETUR_LEGEERKLARING_URL = "$API_BASE_PATH/henvendelse-retur-legeerklaring"
         private const val HENVENDELSE_MELDING_FRA_NAV_URL = "$API_BASE_PATH/henvendelse-meldingfranav"
-        private const val LEGEERKLARING_URL = "/api/v1/genpdf/pale-2/pale-2"
+        private const val LEGEERKLARING_URL = "$API_BASE_PATH/legeerklaring"
 
         val log: Logger = LoggerFactory.getLogger(PdfGenClient::class.java)
         val illegalCharsRegex = Regex("""[^\t\r\n\x20-\x7E\x80-\xFF]""")

--- a/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
@@ -40,7 +40,6 @@ class ExternalMockEnvironment private constructor() {
 
     val pdfgenClient = PdfGenClient(
         pdfGenBaseUrl = environment.clients.dialogmeldingpdfgen.baseUrl,
-        legeerklaringPdfGenBaseUrl = environment.clients.dialogmeldingpdfgen.baseUrl,
         httpClient = mockHttpClient,
     )
     val azureAdClient = AzureAdClient(

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -44,9 +44,6 @@ fun testEnvironment() = Environment(
         dialogmeldingpdfgen = OpenClientEnvironment(
             baseUrl = "pdfGenClientUrl"
         ),
-        legeerklaringpdfgen = OpenClientEnvironment(
-            baseUrl = "pdfGenClientUrl"
-        ),
         padm2 = ClientEnvironment(
             baseUrl = "padm2Url",
             clientId = "dev-gcp.teamsykefravr.padm2",

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdfGenClientMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdfGenClientMock.kt
@@ -18,7 +18,7 @@ suspend fun MockRequestHandleScope.pdfGenClientMockResponse(request: HttpRequest
         requestUrl.endsWith("$apiBasePath/foresporselompasient-paminnelse") -> {
             respond(content = UserConstants.PDF_FORESPORSEL_OM_PASIENT_PAMINNELSE)
         }
-        requestUrl.endsWith("/api/v1/genpdf/pale-2/pale-2") -> {
+        requestUrl.endsWith("$apiBasePath/legeerklaring") -> {
             val bodyString = String(request.body.toByteArray(), Charsets.UTF_8)
             if (Regex("""[^\t\r\n\x20-\x7E\x80-\xFF]""").containsMatchIn(bodyString)) {
                 respond(content = "Bad request - illegal characters in body".toByteArray(), status = HttpStatusCode.BadRequest)


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Bruke `ispdfgen` for å generere pdf for innkommende legeerklæringer