### PR TITLE
IS-4010: Add utgaende_published_at

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/IMeldingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IMeldingRepository.kt
@@ -26,9 +26,11 @@ interface IMeldingRepository {
     suspend fun getUbesvarteMeldingerTilBehandler(fristDato: OffsetDateTime): List<Melding.MeldingTilBehandler>
     suspend fun updateUbesvartPublishedAt(uuid: UUID)
     fun updateInnkommendePublishedAt(uuid: UUID)
+    fun updateUtgaendePublishedAt(uuid: UUID)
     fun getVedlegg(uuid: UUID, number: Int): VedleggPdf?
     fun createVedlegg(pdf: ByteArray, meldingId: PMelding.Id, number: Int, connection: Connection): Int
     fun getUnpublishedMeldingerFraBehandler(): List<Melding.MeldingFraBehandler>
+    fun getUnpublishedMeldingerTilBehandler(): List<Melding.MeldingFraBehandler>
     fun getUnpublishedAvvisteMeldinger(): List<Melding.MeldingTilBehandler>
     fun updateAvvistMeldingPublishedAt(uuid: UUID)
     fun getIkkeJournalforteMeldingerTilBehandler(): List<Pair<Melding.MeldingTilBehandler, ByteArray>>

--- a/src/main/kotlin/no/nav/syfo/application/MeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/MeldingService.kt
@@ -341,6 +341,9 @@ class MeldingService(
             meldingTilBehandler = meldingTilBehandler,
             meldingPdf = pdf,
         )
+        meldingRepository.updateUtgaendePublishedAt(
+            uuid = meldingTilBehandler.uuid,
+        )
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/domain/PMelding.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/domain/PMelding.kt
@@ -24,6 +24,7 @@ data class PMelding(
     val document: List<DocumentComponentDTO>,
     val antallVedlegg: Int,
     val innkommendePublishedAt: OffsetDateTime?,
+    val utgaendePublishedAt: OffsetDateTime?,
     val journalpostId: String?,
     val ubesvartPublishedAt: OffsetDateTime?,
     val veilederIdent: String?,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/MeldingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/MeldingRepository.kt
@@ -162,6 +162,20 @@ class MeldingRepository(private val database: DatabaseInterface) : IMeldingRepos
         }
     }
 
+    override fun updateUtgaendePublishedAt(uuid: UUID) {
+        database.connection.use { connection ->
+            val rowCount = connection.prepareStatement(QUERY_UPDATE_UTGAENDE_PUBLISHED_AT).use {
+                it.setObject(1, OffsetDateTime.now())
+                it.setString(2, uuid.toString())
+                it.executeUpdate()
+            }
+            if (rowCount != 1) {
+                throw SQLException("Failed to update published_at for ubesvart melding with uuid: $uuid ")
+            }
+            connection.commit()
+        }
+    }
+
     override fun getVedlegg(uuid: UUID, number: Int): VedleggPdf? =
         database.connection.use { connection ->
             connection.prepareStatement(QUERY_GET_VEDLEGG).use {
@@ -174,6 +188,13 @@ class MeldingRepository(private val database: DatabaseInterface) : IMeldingRepos
     override fun getUnpublishedMeldingerFraBehandler(): List<Melding.MeldingFraBehandler> =
         database.connection.use { connection ->
             connection.prepareStatement(QUERY_GET_UNPUBLISHED_MELDINGER_FRA_BEHANDLER).use {
+                it.executeQuery().toList { toPMelding().toMeldingFraBehandler() }
+            }
+        }
+
+    override fun getUnpublishedMeldingerTilBehandler(): List<Melding.MeldingFraBehandler> =
+        database.connection.use { connection ->
+            connection.prepareStatement(QUERY_GET_UNPUBLISHED_MELDINGER_TIL_BEHANDLER).use {
                 it.executeQuery().toList { toPMelding().toMeldingFraBehandler() }
             }
         }
@@ -414,6 +435,13 @@ class MeldingRepository(private val database: DatabaseInterface) : IMeldingRepos
                 WHERE uuid = ?
             """
 
+        private const val QUERY_UPDATE_UTGAENDE_PUBLISHED_AT =
+            """
+                UPDATE MELDING
+                SET utgaende_published_at = ?
+                WHERE uuid = ?
+            """
+
         private const val QUERY_GET_VEDLEGG =
             """
                 SELECT vedlegg.* 
@@ -427,6 +455,14 @@ class MeldingRepository(private val database: DatabaseInterface) : IMeldingRepos
                 SELECT *
                 FROM MELDING
                 WHERE innkommende AND innkommende_published_at IS NULL
+                ORDER BY created_at ASC
+            """
+
+        private const val QUERY_GET_UNPUBLISHED_MELDINGER_TIL_BEHANDLER =
+            """
+                SELECT *
+                FROM MELDING
+                WHERE NOT innkommende AND utgaende_published_at IS NULL
                 ORDER BY created_at ASC
             """
 
@@ -557,6 +593,7 @@ private fun ResultSet.toPMelding() =
         document = mapper.readValue(getString("document"), object : TypeReference<List<DocumentComponentDTO>>() {}),
         antallVedlegg = getInt("antall_vedlegg"),
         innkommendePublishedAt = getObject("innkommende_published_at", OffsetDateTime::class.java),
+        utgaendePublishedAt = getObject("utgaende_published_at", OffsetDateTime::class.java),
         journalpostId = getString("journalpost_id"),
         ubesvartPublishedAt = getObject("ubesvart_published_at", OffsetDateTime::class.java),
         veilederIdent = getString("veileder_ident"),

--- a/src/main/resources/db/migration/V4_20__add_published_at.sql
+++ b/src/main/resources/db/migration/V4_20__add_published_at.sql
@@ -1,0 +1,3 @@
+ALTER TABLE MELDING ADD COLUMN utgaende_published_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE MELDING SET utgaende_published_at = created_at WHERE not innkommende

--- a/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiPostTest.kt
+++ b/src/test/kotlin/no/nav/syfo/melding/api/MeldingApiPostTest.kt
@@ -289,6 +289,8 @@ class MeldingApiPostTest {
                         assertEquals(Melding.MeldingType.FORESPORSEL_PASIENT_TILLEGGSOPPLYSNINGER.name, pMelding.type)
                         assertEquals(false, pMelding.innkommende)
                         assertEquals(veilederIdent, pMelding.veilederIdent)
+                        assertNull(pMelding.innkommendePublishedAt)
+                        assertNotNull(pMelding.utgaendePublishedAt)
 
                         val brodtekst =
                             pMelding.document.first { it.key == null && it.type == DocumentComponentType.PARAGRAPH }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Kafka-problemene i det siste har avdekket en mangel her. I går var det er 5 dialogmeldinger som ble lagret i melding-tabellen som ikke ble vellykket lagt på topic.

Følger opp med en ny cronjob etterpå som vil gjøre retry legging på topic. Denne skal også plukke opp de som feilet fra i går (lager et db-script som setter utgaende_published_at til null for de forekomstene det gjelder).