### PR TITLE
IS-4012: Remove meldinger to/from behandler

### DIFF
--- a/src/main/resources/db/migration/V4_22__delete_feilsendt_melding.sql
+++ b/src/main/resources/db/migration/V4_22__delete_feilsendt_melding.sql
@@ -1,0 +1,10 @@
+UPDATE MELDING
+SET tekst = '[Teksten er fjernet]',
+    document = CASE
+       WHEN innkommende THEN '[]'::jsonb
+       ELSE '[{"key": null, "type": "PARAGRAPH", "texts": ["[Teksten er fjernet]"], "title": null}]'::jsonb
+    END
+WHERE uuid IN (
+   '2d110f94-885d-4bf7-a8e8-ec7ead941208',
+   '1685134e-2d5f-4744-9bbe-e9c5163f989b'
+);


### PR DESCRIPTION
Sensurerer innholdet i to meldinger, forespurt på Jira

<details>
  <summary>Gammel løsning på dette</summary>

Sletter et par [forespurte](https://jira.adeo.no/browse/FAGSYSTEM-433212) meldinger og flytter en child til en annen parent slik at meldingsrekkefølgen blir mer logisk.

Mitt opprinnelige query var relativt enkelt:

```sql
DELETE
FROM melding
WHERE uuid IN (
    '2d110f94-885d-4bf7-a8e8-ec7ead941208', /* Feil svar fra behandler */
    '1685134e-2d5f-4744-9bbe-e9c5163f989b' /* Feil svar fra veileder */
);

/* Kobler riktig svar fra behandler med opprinnelig henvendelse */
UPDATE melding
SET conversation_ref = 'b0b272be-cea9-4de1-b66a-16d666a11339', parent_ref = 'f5228df3-5ab4-41d2-b5e0-def7a4bf46df'
WHERE uuid = '253b0f6a-9997-4479-b630-483331db265a';
```

Men Copilot foreslo at jeg legger til et par pre-checks på forhånd slik at det ikke tilfeldigvis har dukket opp noen meldinger før migrasjonen som deretter blir orphaned. Jeg har kjørt noen manuelle dry-runs, så det burde gå fint. Men det er greit å få noen øyne på dette her, likevel!

<details>
  <summary>Sensurerte meldinger fra database</summary>
  
  ```json
[
  {
    "id": "712294",
    "uuid": "1685134e-2d5f-4744-9bbe-e9c5163f989b",
    "created_at": "2026-05-20T11:54:52.401095Z",
    "tidspunkt": "2026-05-20T11:54:52.23079Z",
    "retning": "UTGAENDE_TIL_BEHANDLER",
    "type": "HENVENDELSE_MELDING_FRA_NAV",
    "conversation_ref": "96a3aac1-34fd-46ca-988f-a594b8d9ac04",
    "parent_ref": "",
    "msg_id": "",
    "journalpost_id": "752761686",
    "behandler_navn": behandler,
    "behandler_ref": "4c84e7e5-b70e-4680-8317-57077c395429",
    "antall_vedlegg": "0",
    "innkommende_published_at": "",
    "utgaende_published_at": "2026-05-20T11:54:52.401095Z",
    "ubesvart_published_at": "",
    "avvist_published_at": "",
    "latest_status": "OK",
    "latest_status_tekst": ""
  },
  {
    "id": "712514",
    "uuid": "253b0f6a-9997-4479-b630-483331db265a",
    "created_at": "2026-05-20T13:17:14.825172Z",
    "tidspunkt": "2026-05-20T13:17:13Z",
    "retning": "INNKOMMENDE_FRA_BEHANDLER",
    "type": "HENVENDELSE_MELDING_FRA_NAV",
    "conversation_ref": "96a3aac1-34fd-46ca-988f-a594b8d9ac04",
    "parent_ref": "1685134e-2d5f-4744-9bbe-e9c5163f989b",
    "msg_id": "d8510deb-7ac5-4d93-b973-f5f51858ca66",
    "journalpost_id": "",
    "behandler_navn": behandler,
    "behandler_ref": "",
    "antall_vedlegg": "0",
    "innkommende_published_at": "2026-05-20T13:26:38.319655Z",
    "utgaende_published_at": "",
    "ubesvart_published_at": "",
    "avvist_published_at": "",
    "latest_status": "",
    "latest_status_tekst": ""
  },
  {
    "id": "697819",
    "uuid": "f5228df3-5ab4-41d2-b5e0-def7a4bf46df",
    "created_at": "2026-05-04T11:26:21.663547Z",
    "tidspunkt": "2026-05-04T11:26:21.507882Z",
    "retning": "UTGAENDE_TIL_BEHANDLER",
    "type": "HENVENDELSE_MELDING_FRA_NAV",
    "conversation_ref": "b0b272be-cea9-4de1-b66a-16d666a11339",
    "parent_ref": "",
    "msg_id": "",
    "journalpost_id": "750314276",
    "behandler_navn": behandler,
    "behandler_ref": "4c84e7e5-b70e-4680-8317-57077c395429",
    "antall_vedlegg": "0",
    "innkommende_published_at": "",
    "utgaende_published_at": "2026-05-04T11:26:21.663547Z",
    "ubesvart_published_at": "",
    "avvist_published_at": "",
    "latest_status": "OK",
    "latest_status_tekst": ""
  },
  {
    "id": "707177",
    "uuid": "2d110f94-885d-4bf7-a8e8-ec7ead941208",
    "created_at": "2026-05-13T12:07:54.5376Z",
    "tidspunkt": "2026-05-13T12:07:52Z",
    "retning": "INNKOMMENDE_FRA_BEHANDLER",
    "type": "HENVENDELSE_MELDING_FRA_NAV",
    "conversation_ref": "b0b272be-cea9-4de1-b66a-16d666a11339",
    "parent_ref": "f5228df3-5ab4-41d2-b5e0-def7a4bf46df",
    "msg_id": "533e7508-f4d0-49a1-b34d-8ad9cff22646",
    "journalpost_id": "",
    "behandler_navn": behandler,
    "behandler_ref": "",
    "antall_vedlegg": "0",
    "innkommende_published_at": "2026-05-13T12:12:42.45867Z",
    "utgaende_published_at": "",
    "ubesvart_published_at": "",
    "avvist_published_at": "",
    "latest_status": "",
    "latest_status_tekst": ""
  }
]
```
</details>

</details>